### PR TITLE
Fix redirect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ and to meet some of our community members.
 ## Where to Contribute
 
 1.  If you wish to change this lesson,
-    please work in <https://github.com/swcarpentry/instructor-training>,
-    which can be viewed at <https://swcarpentry.github.io/instructor-training>.
+    please work in <https://github.com/carpentries/instructor-training>,
+    which can be viewed at <https://carpentries.github.io/instructor-training>.
 
 2.  If you wish to change the example lesson,
     please work in <https://github.com/swcarpentry/lesson-example>,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ instructor-training
 ===================
 
 The instructor training course for [Software Carpentry][swc-site] and [Data Carpentry][dc-site].
-Please see <https://swcarpentry.github.io/instructor-training/> for a rendered version of this material,
+Please see <https://carpentries.github.io/instructor-training/> for a rendered version of this material,
 [the lesson template documentation][lesson-example]
 for instructions on formatting, building, and submitting material,
 or run `make` in this directory for a list of helpful commands.

--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ example_repo: "https://github.com/swcarpentry/lesson-example"
 example_site: "https://swcarpentry.github.com/lesson-example"
 workshop_repo: "https://github.com/swcarpentry/workshop-template"
 workshop_site: "https://swcarpentry.github.io/workshop-template"
-training_site: "https://swcarpentry.github.io/instructor-training"
+training_site: "https://carpentries.github.io/instructor-training"
 
 # Surveys.
 pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -237,10 +237,10 @@ Best,
 [training-template]: https://github.com/swcarpentry/training-template
 [minute-cards-template]: https://docs.google.com/forms/d/1ZvNx2co9BLEBTzDavUE7ZkAhkekBa19_5aIRFAdQIqw/edit
 [checkout-checklist]: http://www.datacarpentry.org/checkout/
-[training-repo]: http://swcarpentry.github.io/instructor-training/
+[training-repo]: http://carpentries.github.io/instructor-training/
 [zoom-home]: https://www.zoom.us/
 [demo-video]: https://www.youtube.com/watch?v=FFO2cq-3PPg
 [demo-pad]: http://pad.software-carpentry.org/teaching-demos
-[demo-rubric]: https://github.com/swcarpentry/instructor-training/blob/gh-pages/files/teaching-demo-rubric.md
+[demo-rubric]: https://github.com/carpentries/instructor-training/blob/gh-pages/files/teaching-demo-rubric.md
 
 

--- a/_extras/partner_policy.md
+++ b/_extras/partner_policy.md
@@ -8,10 +8,10 @@ survey_link:
 
 Welcome to the Software Carpentry and Data Carpentry community.  We are excited to welcome you as a member organization. Our instructor training process is a large part of how we spread the teaching culture of the Carpentries to new organizations. We’re looking forward to meeting your team and bringing them up to speed on how we teach so we can have the best impact on our learners.
 
-Your annual membership gives you a number of slots in our instructor training program.  This is a training for people who want to become instructors with the Carpentries (Software Carpentry and Data Carpentry). The workshop is a mix of lectures and hands-on lessons and is very interactive where trainees practice giving short lessons using approaches learned and implement some of the teaching techniques which we will discuss. This is training about pedagogical approach to teaching, not technical training specific to particular lessons. Trainees do not need any particular technical background, and we will not be teaching our workshop curriculum to trainees. This workshop is based on our constantly revised and updated open sourced [curriculum for instructor training](https://swcarpentry.github.io/instructor-training/). 
+Your annual membership gives you a number of slots in our instructor training program.  This is a training for people who want to become instructors with the Carpentries (Software Carpentry and Data Carpentry). The workshop is a mix of lectures and hands-on lessons and is very interactive where trainees practice giving short lessons using approaches learned and implement some of the teaching techniques which we will discuss. This is training about pedagogical approach to teaching, not technical training specific to particular lessons. Trainees do not need any particular technical background, and we will not be teaching our workshop curriculum to trainees. This workshop is based on our constantly revised and updated open sourced [curriculum for instructor training](https://carpentries.github.io/instructor-training/). 
 
 Our trainings are all offered as two day, online events.  You can view our [training calendar](
-https://swcarpentry.github.io/instructor-training/training_calendar/) and sign up for a training that meets your team’s needs. A few points as you select dates:
+https://carpentries.github.io/instructor-training/training_calendar/) and sign up for a training that meets your team’s needs. A few points as you select dates:
 
 * We recommend that you sign up for an event during the first six months of your membership year.  This ensures your trainees have time to complete the training program and start teaching workshops during your membership year.
 * You must sign up for this training at  least four weeks in advance. Events may be cancelled if no member organizations sign up by four weeks in advance.
@@ -34,7 +34,7 @@ Once you’ve confirmed dates and participants, here is some information about p
 
 Lastly, some information about what happens after the event:
 
-* Participants will have three months (90 days) to complete [post-training homework exercises](http://swcarpentry.github.io/instructor-training/checkout/) required to receive their instructor certificate.   
+* Participants will have three months (90 days) to complete [post-training homework exercises](http://carpentries.github.io/instructor-training/checkout/) required to receive their instructor certificate.   
 * Participants who fail to complete these exercises will not be eligible for instructor certification. Extensions may be granted at the discretion of Carpentries staff. 
 * After successfully completing the post-training exercises, participants will receive a PDF certificate attesting they are certified Carpentries instructors.
 * Participants will receive ongoing support and mentorship from Carpentries staff and experienced instructors to help them start teaching at their own institution or other locations.

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,6 +1,6 @@
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
-[concept-maps]: http://swcarpentry.github.io/instructor-training/08-memory/
+[concept-maps]: http://carpentries.github.io/instructor-training/08-memory/
 [contact]: mailto:lessons@software-carpentry.org
 [contrib-covenant]: http://contributor-covenant.org/
 [contributing]: {{ site.github.repository_url }}/blob/gh-pages/CONTRIBUTING.md
@@ -28,7 +28,7 @@
 [ruby-installer]: http://rubyinstaller.org/
 [rubygems]: https://rubygems.org/pages/download/
 [styles]: https://github.com/swcarpentry/styles/
-[training]: http://swcarpentry.github.io/instructor-training/
+[training]: http://carpentries.github.io/instructor-training/
 [workshop-repo]: {{ site.workshop_repo }}
 [yaml]: http://yaml.org/
 [coc]: https://software-carpentry.org/conduct/

--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -208,7 +208,7 @@ example_repo: "https://github.com/swcarpentry/lesson-example"
 example_site: "https://swcarpentry.github.com/lesson-example"
 workshop_repo: "https://github.com/swcarpentry/workshop-template"
 workshop_site: "https://swcarpentry.github.io/workshop-template"
-training_site: "https://swcarpentry.github.io/instructor-training"
+training_site: "https://carpentries.github.io/instructor-training"
 
 # Surveys.
 pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="

--- a/files/messages/checkout.txt
+++ b/files/messages/checkout.txt
@@ -4,7 +4,7 @@ Thanks again for taking part in instructor training this week. I really enjoyed 
 
 We'd be very grateful if you could take a couple of minutes to fill in this survey (https://www.surveymonkey.com/r/post-instructor-training) to provide anonymous feedback about the workshop.
 
-In order to wrap up, we would like you to do the steps outlined in http://swcarpentry.github.io/instructor-training/checkout/:
+In order to wrap up, we would like you to do the steps outlined in http://carpentries.github.io/instructor-training/checkout/:
 
 1. Submit something for one of our lessons.
 

--- a/files/messages/welcome.txt
+++ b/files/messages/welcome.txt
@@ -8,11 +8,9 @@ Importantly, class will be from 9:00 am - 4:15 pm both days. We will have a one 
 
 **In order to prepare:**
 
-1.  Please read these three short papers, which provide a brief overview of some key evidence-based results in teaching:
+1.  Please this paper, which provides a brief overview of some key evidence-based results in teaching:
 
-    * "The Science of Learning" (https://swcarpentry.github.io/instructor-training/files/papers/science-of-learning-2015.pdf)
-    * "Success in Introductory Programming: What Works?" (https://swcarpentry.github.io/instructor-training/files/papers/porter-what-works-2013.pdf)
-    * "What Can I Do Today to Create a More Inclusive Community in CS?" (https://swcarpentry.github.io/instructor-training/files/papers/lee-create-inclusive-community-2015.pdf)
+    * "The Science of Learning" (https://http://carpentries.github.io/instructor-training/checkout/.github.io/instructor-training/files/papers/science-of-learning-2015.pdf)
 
 2.  Please go to the Software Carpentry lessons page (http://software-carpentry.org/lessons/) and the Data Carpentry lessons page (http://www.datacarpentry.org/lessons/), have a look at what we currently teach, and then choose *one episode* from the list at the bottom of this message and read through it carefully. You will be using your selected episode for several in-class exercises, so be sure you are comfortable with the content.
 
@@ -24,7 +22,7 @@ Importantly, class will be from 9:00 am - 4:15 pm both days. We will have a one 
 
 **After the instructor training workshop:**
 
-Please note that after this course is over, you will be asked to do three short follow-up exercises online in order to finish qualifying as an instructor: the details are available at http://swcarpentry.github.io/instructor-training/checkout/.  If you have any questions about the workshop, the reading material, or anything else, please get in touch. Also, you will hear about many ways to stay engaged with each other and with Software and Data Carpentry Instructors around the world, so we look forward to your continued participation!
+Please note that after this course is over, you will be asked to do three short follow-up exercises online in order to finish qualifying as an instructor: the details are available at http://carpentries.github.io/instructor-training/checkout/.  If you have any questions about the workshop, the reading material, or anything else, please get in touch. Also, you will hear about many ways to stay engaged with each other and with Software and Data Carpentry Instructors around the world, so we look forward to your continued participation!
 
 Thanks again,
 

--- a/files/rubric.md
+++ b/files/rubric.md
@@ -56,13 +56,13 @@ Please note that as a condition of taking this training:
     <http://datacarpentry.org/code-of-conduct/>.
 -   You must complete three short tasks after the course in order to
     complete certification. The tasks are described at
-    <http://swcarpentry.github.io/instructor-training/checkout/>, and
+    <http://carpentries.github.io/instructor-training/checkout/>, and
     take a total of approximately 8-10 hours.
 -   You are expected to teach at a Software Carpentry or Data Carpentry
     workshop within 12 months of the course.
 
 For more information on Software and Data Carpentry instructor training,
-please see <http://swcarpentry.github.io/instructor-training/>.
+please see <http://carpentries.github.io/instructor-training/>.
 
 > Applications for the open Fall 2016 online instructor training class are
 > now closed, but we are still accepting applications for subsequent
@@ -228,7 +228,7 @@ Description of your previous experience in teaching:
 
 [_] I agree to complete this training within three months of the training
     course.  The completion steps are described at
-    <http://swcarpentry.github.io/instructor-training/checkout/> and take a
+    <http://carpentries.github.io/instructor-training/checkout/> and take a
     total of approximately 8-10 hours.
 
 [_] I agree to teach a Software Carpentry or Data Carpentry workshop

--- a/setup.md
+++ b/setup.md
@@ -2,7 +2,7 @@
 layout: page
 title: Setup
 permalink: /setup/
-training_site: https://swcarpentry.github.io/instructor-training
+training_site: https://carpentries.github.io/instructor-training
 ---
 
 1.  Please read ["The Science of Learning"]({{ page.training_site }}/files/papers/science-of-learning-2015.pdf), which provides a brief overview of some key evidence-based results in teaching.


### PR DESCRIPTION
Change all hard-coded links from swcarpentry.github.io/instructor-training to carpentries.github.io/instructor-training. Also changes links to github.com/swcarpentry/instructor-training to github.com/carpentries/instructor-training. 

Hope that this will solve redirect issue.

@tracykteal @maneesha @rgaiacs @ChristinaLK Could you please review and merge?