### PR TITLE
WorldCat link rather than link to specific seller

### DIFF
--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -45,7 +45,7 @@ Our approach is based on the work of researchers like Benner,
 who applied the [Dreyfus model of skill acquisition][wikipedia-dreyfus-skill]
 in her studies of
 [how nurses progress from novice to expert](http://journals.sagepub.com/doi/10.1177/0270467604265061) 
-([see also books by Patricia Benner](https://www.amazon.com/Patricia-E.-Benner/e/B001IGLSW4)). This work indicates that 
+([see also books by Patricia Benner](https://www.worldcat.org/search?q=au%3ABenner%2C+Patricia+E.&qt=hot_author#x0%253Abook-%2C%2528x0%253Abook%2Bx4%253Aprintbook%2529%2C%2528x0%253Abook%2Bx4%253Adigital%2529%2C%2528x0%253Abook%2Bx4%253Athsis%2529format)). This work indicates that 
 through practice and formal instruction, learners acquire skills and advance through distinct stages. In simplified form,
 the three stages of this model are:
 


### PR DESCRIPTION
Currently, the list of books by Patricia Benner is an Amazon link.
I think it would be more reasonable to link to a general catalogue of books (WorldCat seems exhaustive enough) and let the reader choose their preferred seller, rather than directly providing them with a link to a specific seller we might seem to give preference to.


