### PR TITLE
remove print statement

### DIFF
--- a/_episodes/14-lesson-study.md
+++ b/_episodes/14-lesson-study.md
@@ -101,7 +101,7 @@ the instructor gains important information about which aspects of subsetting are
 >
 > ```{r}
 > m <- matrix(1:18, nrow=3, ncol=6)
-> print(m)
+> m
 > ```
 >
 > 1. Which of the following commands will extract the values 11 and 14?


### PR DESCRIPTION
this is probably a left over from the translation of the lesson from python, and not needed. In R, calling a variable at the terminal defaults on the print method.