### PR TITLE
Update emails for reporting code-of-conduct violations

### DIFF
--- a/_episodes/22-practices.md
+++ b/_episodes/22-practices.md
@@ -87,12 +87,15 @@ about how a Carpentry workshop operates.
 If you are an instructor, and believe that someone in a workshop has
 violated the Code of Conduct, you may warn them, ask them to
 apologize, and/or expel them, depending on the severity of the
-violation and whether or not you believe it was intentional.  
-You can also bring in the workshop host to mediate an incident
-if you are uncomfortable or unable to do so yourself.
+violation and whether or not you believe it was intentional.
 
-No matter what you choose to do, please contact the joint Data/Software Carpentry Policy subcommittee by emailing [policy@carpentries.org](mailto:policy@carpentries.org) or C. MacDonnell at [confidential@carpentries.org](mailto:confidential@carpentries.org) as
-soon as you can and let us know what happened so that we can follow-up
+The local workshop host/admin is expected to help enforce the Code of Conduct and 
+you can ask them to mediate an incident if you are uncomfortable or unable to do so yourself.
+
+No matter what you choose to do, please contact the joint Data/Software 
+Carpentry Policy subcommittee by emailing [policy@carpentries.org](mailto:policy@carpentries.org) 
+or C. MacDonnell at [confidential@carpentries.org](mailto:confidential@carpentries.org) 
+as soon as you can and let us know what happened so that we can follow-up
 with the workshop host and/or participants as needed.
 
 You also have the right as an instructor to walk out of a workshop

--- a/_episodes/22-practices.md
+++ b/_episodes/22-practices.md
@@ -89,7 +89,7 @@ violated the Code of Conduct, you may warn them, ask them to
 apologize, and/or expel them, depending on the severity of the
 violation and whether or not you believe it was intentional.
 
-The local workshop host/admin is expected to help enforce the Code of Conduct and 
+The local workshop host is expected to help enforce the Code of Conduct and 
 you can ask them to mediate an incident if you are uncomfortable or unable to do so yourself. 
 If you choose to settle the issue yourself, you should notify the workshop host 
 of the issue in case s/he feels additional steps should be taken.

--- a/_episodes/22-practices.md
+++ b/_episodes/22-practices.md
@@ -91,10 +91,7 @@ violation and whether or not you believe it was intentional.
 You can also bring in the workshop host to mediate an incident
 if you are uncomfortable or unable to do so yourself.
 
-No matter what you choose to do, please contact the appropriate
-Carpentry administrator at
-[admin@software-carpentry.org](mailto:admin@software-carpentry.org)
-or [admin@datacarpentry.org](mailto:admin@datacarpentry.org) as
+No matter what you choose to do, please contact the joint Data/Software Carpentry Policy subcommittee by emailing [policy@carpentries.org](mailto:policy@carpentries.org) or C. MacDonnell at [confidential@carpentries.org](mailto:confidential@carpentries.org) as
 soon as you can and let us know what happened so that we can follow-up
 with the workshop host and/or participants as needed.
 

--- a/_episodes/22-practices.md
+++ b/_episodes/22-practices.md
@@ -90,7 +90,9 @@ apologize, and/or expel them, depending on the severity of the
 violation and whether or not you believe it was intentional.
 
 The local workshop host/admin is expected to help enforce the Code of Conduct and 
-you can ask them to mediate an incident if you are uncomfortable or unable to do so yourself.
+you can ask them to mediate an incident if you are uncomfortable or unable to do so yourself. 
+If you choose to settle the issue yourself, you should notify the workshop host 
+of the issue in case s/he feels additional steps should be taken.
 
 No matter what you choose to do, please contact the joint Data/Software 
 Carpentry Policy subcommittee by emailing [policy@carpentries.org](mailto:policy@carpentries.org) 


### PR DESCRIPTION
This updates the relevant section of the instructor training with the new `@carpentries.org` email addresses for follow-up to code-of-conduct violations occurring during a workshop. (https://github.com/carpentries/instructor-training/issues/567) 