### PR TITLE
Updated issues links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,19 +50,19 @@ and to meet some of our community members.
     which can be viewed at <https://carpentries.github.io/instructor-training>.
 
 2.  If you wish to change the example lesson,
-    please work in <https://github.com/carpentries/lesson-example>,
+    please work in <https://github.com/swcarpentry/lesson-example>,
     which documents the format of our lessons
-    and can be viewed at <https://carpentries.github.io/lesson-example>.
+    and can be viewed at <https://swcarpentry.github.io/lesson-example>.
 
 3.  If you wish to change the template used for workshop websites,
-    please work in <https://github.com/carpentries/workshop-template>.
+    please work in <https://github.com/swcarpentry/workshop-template>.
     The home page of that repository explains how to set up workshop websites,
-    while the extra pages in <https://carpentries.github.io/workshop-template>
+    while the extra pages in <https://swcarpentry.github.io/workshop-template>
     provide more background on our design choices.
 
 4.  If you wish to change CSS style files, tools,
     or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`,
-    please work in <https://github.com/carpentries/styles>.
+    please work in <https://github.com/swcarpentry/styles>.
 
 ## What to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ You can also [reach us by email][contact].
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/swcarpentry/instructor-training/issues/
+[issues]: https://github.com/carpentries/instructor-training/issues/
 [repo]: https://github.com/swcarpentry/instructor-training/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,19 +50,19 @@ and to meet some of our community members.
     which can be viewed at <https://carpentries.github.io/instructor-training>.
 
 2.  If you wish to change the example lesson,
-    please work in <https://github.com/swcarpentry/lesson-example>,
+    please work in <https://github.com/carpentries/lesson-example>,
     which documents the format of our lessons
-    and can be viewed at <https://swcarpentry.github.io/lesson-example>.
+    and can be viewed at <https://carpentries.github.io/lesson-example>.
 
 3.  If you wish to change the template used for workshop websites,
-    please work in <https://github.com/swcarpentry/workshop-template>.
+    please work in <https://github.com/carpentries/workshop-template>.
     The home page of that repository explains how to set up workshop websites,
-    while the extra pages in <https://swcarpentry.github.io/workshop-template>
+    while the extra pages in <https://carpentries.github.io/workshop-template>
     provide more background on our design choices.
 
 4.  If you wish to change CSS style files, tools,
     or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`,
-    please work in <https://github.com/swcarpentry/styles>.
+    please work in <https://github.com/carpentries/styles>.
 
 ## What to Contribute
 
@@ -145,7 +145,7 @@ You can also [reach us by email][contact].
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/carpentries/instructor-training/issues/
-[repo]: https://github.com/swcarpentry/instructor-training/
+[repo]: https://github.com/carpentries/instructor-training/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/
 [swc-site]: http://software-carpentry.org/


### PR DESCRIPTION
The [issues] link, defined at the bottom of the page, needed to be updated from:
https://github.com/swcarpentry/instructor-training/issues/
to:
https://github.com/carpentries/instructor-training/issues/