### PR TITLE
Add "active learning" to assessment header

### DIFF
--- a/_episodes/05-memory.md
+++ b/_episodes/05-memory.md
@@ -98,7 +98,7 @@ more information in your head at once. This is one reason
 why helping our learners to see the connections among 
 the concepts we are teaching is so important.  
 
-## Formative Assessment
+## Active Learning Through Formative Assessment
 
 Formative assessment is a key component in helping learners solidify their understanding 
 and transfer ideas from short-term memory into long-term memory. It's important


### PR DESCRIPTION
This clarifies the reason for returning to formative assessment in this context. It also adds a reference to "active learning" which is mentioned in the teaching practices worksheet but not named elsewhere (see issue https://github.com/carpentries/instructor-training/issues/589 ). This quick fix does not fully resolve that issue, but it's a start. 


