### PR TITLE
Use correct URL for SWC books

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -27,7 +27,7 @@ you will be asked to do three short follow-up exercises online in order to finis
 the details are available on [the checkout checklist]({{ page.training_site }}/checkout/).
 If you have any questions about the workshop, the reading material, or anything else, please [get in touch](mailto:checkout@carpentries.org).
 
-If you are interested in doing more reading, we have [some recommendations]( {{ page.training_site }}/reference/#books).
+If you are interested in doing more reading, we have [some recommendations]( {{ page.training_site }}/reference).
 
 Episodes
 --------


### PR DESCRIPTION
This pull request links the text

> If you are interested in doing more reading, we have some recommendations

to this link: https://carpentries.github.io/instructor-training/reference

Previously, this link was https://carpentries.github.io/instructor-training/reference#Books which did not work


