### PR TITLE
remove link to DC workshop-template

### DIFF
--- a/_episodes/20-carpentries.md
+++ b/_episodes/20-carpentries.md
@@ -189,8 +189,7 @@ The workshop will show up on our websites shortly thereafter.
 
 > ## Practice With SWC or DC Infrastructure
 >
-> Go to the [SWC workshop template repository]({{ site.workshop_repo }})
-> or the [DC workshop template repository]({{ site.dc_github }}/workshop-template)
+> Go to the [workshop template repository]({{ site.workshop_repo }}) 
 > and follow the directions to create a workshop website using your local location and today's date.
 > Put the link for your workshop website into the Etherpad.
 > 


### PR DESCRIPTION
Now that the Data Carpentry workshop template repository is deprecated, I removed mention of it in this lesson. I also removed "SWC" to avoid confusion. The workshop template is the same for all types of workshops (SWC, DC or LC). There is a variable to set in the template to get the type of workshop needed.