### PR TITLE
Fix license link.

### DIFF
--- a/_episodes/20-carpentries.md
+++ b/_episodes/20-carpentries.md
@@ -141,7 +141,7 @@ be sure to read through the [instructor no-show policy](https://github.com/carpe
 ### Materials
 
 All of Software Carpentry and Data Carpentry's lessons materials are freely available
-under a permissive [open license]({{ page.root }}/license.md).
+under a permissive [open license]({{ page.root }}/LICENSE).
 You may use them whenever and however you want,
 provided you cite the original source.
 


### PR DESCRIPTION
Hi there,
The licensing link was broken on this page. This is a simple fix to correct it.