### PR TITLE
Amazon to worldcat

### DIFF
--- a/_episodes/08-motivation.md
+++ b/_episodes/08-motivation.md
@@ -93,7 +93,7 @@ learners.
 
 > ## Strategies for Motivating Learners
 >
-> *[How Learning Works][amazon-hlw]* by Susan Ambrose, et al., 
+> *[How Learning Works][worldcat-hlw]* by Susan Ambrose, et al., 
 > contains this list of evidence-based methods to motivate learners.
 >
 > In groups of two or three, pick three of these points and briefly describe
@@ -243,8 +243,8 @@ even in subtle ways, can make them anxious about the risk of confirming those st
 their performance. This is called *[stereotype threat][wikipedia-stereotype-threat]*,
 and the clearest examples in computing are gender-related. Depending on whose numbers you trust,
 only 12-18% of programmers are women, and those figures have actually been getting worse over the last 20 years.
-There are many reasons for this (see Margolis and Fisher's *[Unlocking the Clubhouse][amazon-clubhouse]*
-and Margolis's *[Stuck in the Shallow End][amazon-shallow-end]*). Steele's *[Whistling Vivaldi][amazon-whistling-vivaldi]*
+There are many reasons for this (see Margolis and Fisher's *[Unlocking the Clubhouse][wolrd-cat-clubhouse]*
+and Margolis's *[Stuck in the Shallow End][worldcat-shallow-end]*). Steele's *[Whistling Vivaldi][worldcat-whistling-vivaldi]*
 summarizes what we know about stereotype threat in general and presents some strategies for mitigating it in 
 the classroom.
 
@@ -492,10 +492,10 @@ such as:
 
 
 [ada-initiative-resources]: http://adainitiative.org/continue-our-work/impostor-syndrome-training/
-[amazon-clubhouse]: http://www.amazon.com/Unlocking-Clubhouse-Computing-Jane-Margolis/dp/0262632691/
-[amazon-hlw]: http://www.amazon.com/How-Learning-Works-Research-Based-Jossey-Bass/dp/0470484101/
-[amazon-shallow-end]: https://www.amazon.com/Stuck-Shallow-End-Education-Computing/dp/0262514044/
-[amazon-whistling-vivaldi]: http://www.amazon.com/dp/0393339726/
+[worldcat-clubhouse]: https://www.worldcat.org/title/unlocking-the-clubhouse-women-in-computing/oclc/752326915
+[worldcat-hlw]: https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/762968489
+[worldcat-shallow-end]: https://www.worldcat.org/title/stuck-in-the-shallow-end-education-race-and-computing/oclc/792730600
+[worldcat-whistling-vivaldi]: https://www.worldcat.org/title/whistling-vivaldi-and-other-clues-to-how-stereotypes-affect-us/oclc/987873095
 [conference-accessibility]: https://modelviewculture.com/pieces/unlocking-the-invisible-elevator-accessibility-at-tech-conferences
 [deaf-accessibility]: https://modelviewculture.com/pieces/qa-making-tech-events-accessible-to-the-deaf-community
 [four-letter-words]: https://m.signalvnoise.com/four-letter-words-f01603fb704c#.dfulbwp49

--- a/_episodes/11-practice-teaching.md
+++ b/_episodes/11-practice-teaching.md
@@ -30,7 +30,7 @@ From politicians to researchers and teachers themselves,
 most reformers have designed systems to find and promote those who can teach
 and eliminate those who can't.
 As Elizabeth Green describes in
-*[Building a Better Teacher][amazon-babt]*,
+*[Building a Better Teacher][worldcat-babt]*,
 though,
 that assumption is wrong,
 which is why educational reforms based on it have repeatedly failed.
@@ -237,7 +237,7 @@ practice teaching and to get and give feedback tomorrow.
 >Discuss with a partner and then write some thoughts in the Etherpad.
 {: .challenge}
 
-[amazon-babt]: http://www.amazon.com/Building-Better-Teacher-Teaching-Everyone/dp/0393081591/
+[worldcat-babt]: https://www.worldcat.org/title/building-a-better-teacher-how-teaching-works-and-how-to-teach-it-to-everyone/oclc/953075081
 [bad-teaching-video]: https://www.youtube.com/watch?v=-ApVt04rB4U
 [scipy-video-1]: https://vimeo.com/139316669
 [scipy-video-2]: https://vimeo.com/139181120

--- a/files/messages/welcome.txt
+++ b/files/messages/welcome.txt
@@ -31,13 +31,13 @@ Thanks again,
 
 p.s. If you are interested in doing more reading, you may enjoy:
 
-* How Learning Works (http://www.amazon.com/How-Learning-Works-Research-Based-Jossey-Bass/dp/0470484101/), which is an excellent summary of current research in teaching and learning
+* How Learning Works (https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/762968489), which is an excellent summary of current research in teaching and learning
 
-* Building a Better Teacher (http://www.amazon.com/Building-Better-Teacher-Teaching-Everyone/dp/0393081591/), a well-written look at why educational reforms in the past 50 years have mostly missed the mark and about what we should be doing instead.
+* Building a Better Teacher (https://www.worldcat.org/title/building-a-better-teacher-how-teaching-works-and-how-to-teach-it-to-everyone/oclc/953075081), a well-written look at why educational reforms in the past 50 years have mostly missed the mark and about what we should be doing instead.
 
-* Small Teaching (https://www.amazon.com/Small-Teaching-Everyday-Lessons-Learning/dp/1118944496/), which presents strategies for improving teaching practices that don't require significant resources.
+* Small Teaching (https://www.worldcat.org/title/small-teaching-everyday-lessons-from-the-science-of-learning/oclc/968245403), which presents strategies for improving teaching practices that don't require significant resources.
 
-* Teaching What You Don't Know (http://www.amazon.com/Teaching-What-You-Dont-Know/dp/0674066170/), which is a situation many of us find ourselves in more often that we'd like.
+* Teaching What You Don't Know (https://www.worldcat.org/title/teaching-what-you-dont-know/oclc/806492013), which is a situation many of us find ourselves in more often that we'd like.
 
 Episodes
 --------

--- a/reference.md
+++ b/reference.md
@@ -5,42 +5,42 @@ root: .
 
 ## Books
 
-Susan Ambrose et al: *[How Learning Works: Seven Research-Based Principles for Smart Teaching][amazon-hlw]*.
+Susan Ambrose et al: *[How Learning Works: Seven Research-Based Principles for Smart Teaching][worldcat-hlw]*.
 :   An excellent overview of what we know about education and why we
     believe it's true, covering everything from cognitive psychology
     to social factors.
 
-Stephen D. Brookfield and Stephen Preskill: *[The Discussion Book][amazon-discussion]*.
+Stephen D. Brookfield and Stephen Preskill: *[The Discussion Book][worldcat-discussion]*.
 :   Describes fifty different ways to get groups talking productively.
 
-Joshua Foer: *[Moonwalking with Einstein: The Art and Science of Remembering Everything][amazon-moonwalking]*.
+Joshua Foer: *[Moonwalking with Einstein: The Art and Science of Remembering Everything][worldcat-moonwalking]*.
 :   Discusses memory techniques within the context of training for the U.S. Memory Championship. Compelling read and
     also very informative.
 
-Elizabeth Green: *[Building a Better Teacher][amazon-babt]*.
+Elizabeth Green: *[Building a Better Teacher][worldcat-babt]*.
 :   A well-written look at why educational reforms in the past 50 years have mostly missed the mark,
     and what we should be doing instead.
 
-Mark Guzdial: *[Learner-Centered Design of Computing Education: Research on Computing for Everyone][amazon-lcdce]*.
+Mark Guzdial: *[Learner-Centered Design of Computing Education: Research on Computing for Everyone][worldcat-lcdce]*.
 :   A well-researched investigation of what it means to design computing courses for everyone,
     not just people who are going to become professional programmers,
     from one of the leading researchers in CS education.
 
-Doug Lemov: *[Teach Like a Champion 2.0][amazon-tlac]*.
+Doug Lemov: *[Teach Like a Champion 2.0][worldcat-tlac]*.
 :   Presents 62 classroom techniques drawn from intensive study of thousands of hours of video of good teachers in action.
 
-Therese Huston: *[Teaching What You Don't Know][amazon-twydk]*.
+Therese Huston: *[Teaching What You Don't Know][worldcat-twydk]*.
 :   A pointed, funny, and very useful book that explores exactly what the title suggests.
 
-James Lang: *[Small Teaching][amazon-small-teaching]*.
+James Lang: *[Small Teaching][worldcat-small-teaching]*.
 :   A short guide to evidence-based teaching practices that can be adopted
     without requiring large up-front investments of time and money.
 
-Jane Margolis and Allan Fisher: *[Unlocking the Clubhouse: Women in Computing][amazon-clubhouse]*.
+Jane Margolis and Allan Fisher: *[Unlocking the Clubhouse: Women in Computing][worldcat-clubhouse]*.
 :   A groundbreaking report on the gender imbalance in computing,
     and the steps Carnegie-Mellon took to address the problem.
 
-Claude M. Steele: *[Whistling Vivaldi: How Stereotypes Affect Us and What We Can Do][amazon-vivaldi]*.
+Claude M. Steele: *[Whistling Vivaldi: How Stereotypes Affect Us and What We Can Do][worldcat-vivaldi]*.
 :   Explains and explores stereotype threat and strategies for addressing it.
 
 ## Papers
@@ -82,7 +82,7 @@ Gormally et al: "[Feedback about Teaching in Higher Ed: Neglected Opportunities 
 
 Guzdial: "[Why Programming is Hard to Teach]({{ page.root }}/files/papers/guzdial-why-hard-to-teach-2011.pdf)"
 :   A chapter from
-    *[Making Software][amazon-making-software]*
+    *[Making Software][worldcat-making-software]*
     that explores why programming seems so much harder to teach than
     some other standard subjects.
 
@@ -112,16 +112,16 @@ Wilson et al: "[Best Practices for Scientific Computing](http://www.plosbiology.
 Wilson: "[Software Carpentry: Lessons Learned][swc-lessons-learned]"
 :   Summarizes what we've learned in 17 years of running classes for scientists.
 
-[amazon-babt]: http://www.amazon.com/Building-Better-Teacher-Teaching-Everyone/dp/0393081591
-[amazon-clubhouse]: http://www.amazon.com/Unlocking-Clubhouse-Computing-Jane-Margolis/dp/0262632691/
-[amazon-discussion]: https://www.amazon.com/Discussion-Book-Great-People-Talking/dp/1119049717/
-[amazon-moonwalking]: https://www.amazon.com/Moonwalking-Einstein-Science-Remembering-Everything/dp/0143120530
-[amazon-hlw]: http://www.amazon.com/How-Learning-Works-Research-Based-Jossey-Bass/dp/0470484101/
-[amazon-lcdce]: http://www.amazon.com/Learner-Centered-Design-Computing-Education-Human-Centered/dp/1627053514/
-[amazon-making-software]: http://www.amazon.com/Making-Software-Really-Works-Believe/dp/0596808321/
-[amazon-small-teaching]: https://www.amazon.com/Small-Teaching-Everyday-Lessons-Learning/dp/1118944496/
-[amazon-tlac]: http://www.amazon.com/Teach-Like-Champion-2-0-Techniques/dp/1118901851/
-[amazon-twydk]: http://www.amazon.com/Teaching-What-You-Dont-Know/dp/0674066170/
-[amazon-vivaldi]: http://www.amazon.com/Whistling-Vivaldi-Stereotypes-Affect-Issues/dp/0393339726/
+[worldcat-babt]: https://www.worldcat.org/title/building-a-better-teacher-how-teaching-works-and-how-to-teach-it-to-everyone/oclc/953075081
+[worldcat-clubhouse]: https://www.worldcat.org/title/unlocking-the-clubhouse-women-in-computing/oclc/752326915
+[worldcat-discussion]: https://www.worldcat.org/title/discussion-book-50-great-ways-to-get-people-talking/oclc/914221868
+[worldcat-moonwalking]: https://www.worldcat.org/title/moonwalking-with-einstein-the-art-and-science-of-remembering-everything/oclc/1023353802
+[worldcat-hlw]: https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/762968489
+[worldcat-lcdce]: https://www.worldcat.org/title/learner-centered-design-of-computing-education-research-on-computing-for-everyone/oclc/1028934710&referer=brief_results
+[worldcat-making-software]: https://www.worldcat.org/title/making-software-what-really-works-and-why-we-believe-it/oclc/795921229
+[worldcat-small-teaching]: https://www.worldcat.org/title/small-teaching-everyday-lessons-from-the-science-of-learning/oclc/968245403
+[worldcat-tlac]: https://www.worldcat.org/title/teach-like-a-champion-20-62-techniques-that-put-students-on-thepath-to-college/oclc/946587371
+[worldcat-twydk]: https://www.worldcat.org/title/teaching-what-you-dont-know/oclc/806492013
+[worldcat-vivaldi]: https://www.worldcat.org/title/whistling-vivaldi-and-other-clues-to-how-stereotypes-affect-us/oclc/987873095
 [discovering-speech]: https://books.google.com/books?id=IoTdAUdNkgIC&pg=PA302#v=onepage&q&f=false/
 [swc-lessons-learned]: http://f1000research.com/articles/3-62/v2


### PR DESCRIPTION
in reference to issue https://github.com/carpentries/instructor-training/issues/544 I have gone through and updated the amazon links to now point to WorldCat