### PR TITLE
Clean up demo rubric for addition to curriculum

### DIFF
--- a/files/teaching-demo-rubric.md
+++ b/files/teaching-demo-rubric.md
@@ -24,7 +24,7 @@ Uses notes on paper/tablet|Displays lesson materials/notes on their screen|
 -|Uses significant amounts of dismissive language (e.g. "just", "easy")|
 Speaks and types at an appropriate (slow enough) pace|Speaks or types very quickly|
 Speaks clearly|-
-Appears focused and attentive to learners|Appears significantly distracted|
+Appears focused and attentive to learners|Appears significantly distracted by content or process of consulting notes|
 
 ---
 

--- a/files/teaching-demo-rubric.md
+++ b/files/teaching-demo-rubric.md
@@ -45,7 +45,7 @@ Date:
 |<br>Embraces & uses mistakes|
 |<br>Use of notes on paper/tablet|
 |<br>Distraction-free screen|
-|<br>Dismissive language|
+|<br>Wording|
 |<br>Pacing|
 |<br>Clarity|
 |<br>Demeanor & focus|

--- a/files/teaching-demo-rubric.md
+++ b/files/teaching-demo-rubric.md
@@ -3,28 +3,28 @@ This rubric is provided as a guide for Trainers evaluating potential new instruc
 Trainer. As such, deviation from this rubric is encouraged as needed to accurately assess the trainee's preparation and instructional
 skills.
 
-In general, trainees who have three or more marks in the "Negative" columns below should be asked to redo their demonstration. Even one 
-mark in a "Negative" column can be justification for asking a trainee to redo their demonstration if the problem is significant. As always,
+In general, these demonstrations have a very low (<5%) failure rate. When a trainee is asked to redo a demo, it is simply a matter of correction -- an error to embrace and to learn from -- not rejection. Trainees who have three or more marks in the "Negative" columns below should probably be asked to redo their demonstration. Even one 
+mark in a "Negative" column can be considered justification for asking a trainee to redo their demonstration if the problem is significant. As always,
 Trainers should use their own judgement when applying this rubric in individual cases.  
 
 |Positive Content|Negative Content|
 |------|---------------------|
-Trainee uses the official curricular materials as written or with minor deviations|Trainee deviates significantly from the official curricular materials|
-Trainee places content in context and explains why it is relevant/useful to the learner|Trainee jumps into the content without explaining context|
-Trainee obviously knows the material they are teaching|Trainee makes factual errors in teaching the content and doesn't correct themselves|
+Uses official curriculum with only minor deviations|Deviates significantly or doesn't use official curriculum|
+Places content in context and explains relevance/utility to learners|Jumps into the content without context|
+Teaches content correctly|Makes factual errors in content and doesn't correct|
 
 |Positive Delivery|Negative Delivery|
 |------|---------------------|
-Trainee mirrors the learner's environment (e.g. default terminal setup, simplified shell prompt)|Trainee uses shortcuts or tools not immediately available to or familiar to the learner|
-Trainee uses appropriately sized fonts and windows|Font or windows are too small|
-Trainee explains everything that they type|Trainee trouble-shoots an error or otherwise types commands without explaining them to the learner|
-Trainee uses mistakes/typos as opportunities for learning|Trainee ignores or dismisses mistakes/typos that they make|
--|Trainee displays the lesson materials/notes on their screen while teaching|
--|Trainee has notifications show up on their screen while teaching|
--|Trainee uses significant amounts of dismissive language (e.g. "just do this", "easy", "simple")|
-Trainee speaks and types at an appropriate pace|Trainee speaks or types very quickly|
-Trainee speaks clearly|-
--|Trainee appears significantly distracted|
+Mirrors the learner's environment (e.g. default terminal setup, simplified prompt)|Uses shortcuts or tools that are unfamiliar/unavailable to learners|
+Uses appropriately sized fonts and windows|Font or windows are too small|
+Explains all typing|Types commands or troubleshoots errors without explaining|
+Uses mistakes/typos as opportunities for learning|Ignores or dismisses mistakes/typos that they make|
+Uses notes on paper/tablet|Displays lesson materials/notes on their screen|
+-|Notifications show up on their screen|
+-|Uses significant amounts of dismissive language (e.g. "just", "easy")|
+Speaks and types at an appropriate (slow enough) pace|Speaks or types very quickly|
+Speaks clearly|-
+Appears focused and attentive to learners|Appears significantly distracted|
 
 ---
 
@@ -36,16 +36,16 @@ Date:
 
 |Aspect|Comments_________________________________________________|
 |------|---------------------|
-|<br>Speed<br>|
-|<br>Voice, teaching style|
-|<br>Verbalize typing|
-|<br>Verbalize thoughts|
-|<br>Explain all that was typed|
-|<br>Easy to follow|
-|<br>font, window size etc|
-|<br>Mirroring Learner’s Environment|
-|<br>Stick to the Material|
-|<br>Embrace Mistakes|
-|<br>Use of Illustrations|
+|<br>Sticks to curriculum<br>|
+|<br>Context|
+|<br>Knowledge|
+|<br>Mirror learner's environment|
+|<br>Font & window size|
+|<br>Explanation of typing|
+|<br>Embraces & uses mistakes|
 |<br>Use of notes on paper/tablet|
-|<br>Avoid Being Disturbed|
+|<br>Distraction-free screen|
+|<br>Dismissive language|
+|<br>Pacing|
+|<br>Clarity|
+|<br>Demeanor & focus|

--- a/files/teaching-demo-rubric.md
+++ b/files/teaching-demo-rubric.md
@@ -3,13 +3,13 @@ This rubric is provided as a guide for Trainers evaluating potential new instruc
 Trainer. As such, deviation from this rubric is encouraged as needed to accurately assess the trainee's preparation and instructional
 skills.
 
-In general, these demonstrations have a very low (<5%) failure rate. When a trainee is asked to redo a demo, it is simply a matter of correction -- an error to embrace and to learn from -- not rejection. Trainees who have three or more marks in the "Negative" columns below should probably be asked to redo their demonstration. Even one 
+In general, these demonstrations have a very high (over 95%) pass rate. When a trainee is asked to redo a demo, it is usually a matter of correction -- an error to embrace and to learn from -- not rejection. Trainees who have three or more marks in the "Negative" columns below should probably be asked to try again. Even one 
 mark in a "Negative" column can be considered justification for asking a trainee to redo their demonstration if the problem is significant. As always,
 Trainers should use their own judgement when applying this rubric in individual cases.  
 
 |Positive Content|Negative Content|
 |------|---------------------|
-Uses official curriculum with only minor deviations|Deviates significantly or doesn't use official curriculum|
+Uses Carpentries curriculum with only minor deviations|Deviates significantly or doesn't use Carpentries curriculum|
 Places content in context and explains relevance/utility to learners|Jumps into the content without context|
 Teaches content correctly|Makes factual errors in content and doesn't correct|
 
@@ -38,7 +38,7 @@ Date:
 |------|---------------------|
 |<br>Sticks to curriculum<br>|
 |<br>Context|
-|<br>Knowledge|
+|<br>Content Knowledge|
 |<br>Mirror learner's environment|
 |<br>Font & window size|
 |<br>Explanation of typing|


### PR DESCRIPTION
Step 1 to address https://github.com/carpentries/instructor-training/issues/657

This PR is intended to prepare the demo rubric for use within the instructor training curriculum, as well as making it more useful to Trainers, particularly those who are new to running teaching demonstration sessions. 

This change:
- adds information about low failure rate to counter fears of trainers and trainees, most of whom have been traumatized by high-stakes testing. 
- simplifies language in the rubric to make it easier to read 
- adds positive actions to two negatives that previously lacked clear opposites
- modifies the note-taking form to directly and sequentially follow the rubric


