### PR TITLE
misc changes to the instructor guide

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -4,6 +4,10 @@ title: "Instructor Notes"
 permalink: /guide/
 ---
 
+Shortcuts to: 
+- Teaching Tips: [Online vs In Person](#-VI.-Differences-Among-Training-Types), [Online Teaching](#-VII.-Zoom-Manual-(Online-Trainings)), [General Recommendations](#IIX.-General-Recommendations)
+- [Running demo sessions](#IX.-Running-a-Teaching-Demonstration)
+
 ## I. Trainer Duties
 As of May 2017, the Trainers group adopted a
 [Trainer Agreement][trainer-agreement] outlining Trainer duties. Only active
@@ -111,24 +115,30 @@ you’re not the host, please contact Carpentry staff immediately.
 
 ### General tips for online training:  
 - **Support the lead**
-- It's tempting to check-out and check email/do work when your co-teacher has taken the wheel.  Try not to do this!  Ways that you can support your co-teacher when they are leading are: 
-  - Monitor the chat in zoom/notes
-  - Help post exercises + provide instructions
-  - Find links or references
-- Make sure that whomever is actively teaching always has host privileges. When you take turns instructing, remember to hand-off host privileges during the change-over.
+	- It's tempting to check-out and check email/do work when your co-teacher has taken the wheel.  Try not to do this!  Ways that you can support your co-teacher when they are leading are: 
+	  - Monitor the chat in zoom/notes
+	  - Help post exercises + provide instructions
+	  - Find links or references
+	- Make sure that whomever is actively teaching always has host privileges. When you take turns instructing, remember to hand-off host privileges during the change-over.
 - **Exercise management**
-- After the first exercise, keep a list of all the participants in a plain text file on your computer so can you can easily paste it into the shared note-taking doc for exercises. (G.W.)
-- Screen-share a timer/countdown clock (like [this timer from timeanddate.com](https://www.timeanddate.com/timer/)) so participants know how long they have to work on exercises. (L.N)
+	- After the first exercise, keep a list of all the participants in a plain text file on your computer so can you can easily paste it into the shared note-taking doc for exercises. (G.W.)
+	- Screen-share a timer/countdown clock (like [this timer from timeanddate.com](https://www.timeanddate.com/timer/)) so participants know how long they have to work on exercises. (L.N)
 - **Zoom tips**
-- “Gallery view” in the upper right toggles the display to show more participants' videos.  
-- “Share screen” is at the bottom middle of the screen. To end “share screen”, click the red button that will appear at the top middle of the screen when you are in screen sharing mode.  
-- When you screen share, you have the option to share individual apps or your entire desktop. The default is the full desktop.
-- The Zoom chat is not stable (it is not saved across sessions or after going into breakout rooms). We highly recommend using the Etherpad or Google Doc chat instead. For those who want to save the chat, they do that using the "More" option in the chat window, which offers "Save chat". Choosing this will save the chat to a local text file on the person's computer.
-- During breaks, learners will often turn off their video and wait for your audio cue to re-activate. This makes it look like no one is back from break, but just saying 'hello' will generally get a bunch of people to come back on video quickly.
-- When several attendees are in the same room (member trainings): it is helpful to have every participant log in separately so that you can see names and faces and they can interact by waving or using the chat. However, it is important that only one microphone and speaker should be active in the room at one time or feedback and noise will be a problem. When creating breakouts, you can either leave these people in the main room or shuffle people around to create a room just for them. Either way, ask them to leave a mic on so you can listen in.
-- Attendees might like to have a separate room (without Trainers) to network in over lunch or other breaks. Be prepared to assign that room and then close it to restart the main session.
+	- “Gallery view” in the upper right toggles the display to show more participants' videos.  
+	- “Share screen” is at the bottom middle of the screen. To end “share screen”, click the red button that will appear at the top middle of the screen when you are in screen sharing mode.  
+	- When you screen share, you have the option to share individual apps or your entire desktop. The default is the full desktop.
+	- The Zoom chat is not stable (it is not saved across sessions or after going into breakout rooms). We highly recommend using the Etherpad or Google Doc chat instead. For those who want to save the chat, they do that using the "More" option in the chat window, which offers "Save chat". Choosing this will save the chat to a local text file on the person's computer.
+	- During breaks, learners will often turn off their video and wait for your audio cue to re-activate. This makes it look like no one is back from break, but just saying 'hello' will generally get a bunch of people to come back on video quickly.
+	- When several attendees are in the same room (member trainings): it is helpful to have every participant log in separately so that you can see names and faces and they can interact by waving or using the chat. However, it is important that only one microphone and speaker should be active in the room at one time or feedback and noise will be a problem. When creating breakouts, you can either leave these people in the main room or shuffle people around to create a room just for them. Either way, ask them to leave a mic on so you can listen in.
+	- Attendees might like to have a separate room (without Trainers) to network in over lunch or other breaks. Be prepared to assign that room and then close it to restart the main session.
 
-## IIX. Running a Teaching Demonstration  
+## IIX. General Recommendations
+
+### Using slides
+
+### Preparing material
+
+## IX. Running a Teaching Demonstration  
 
 If you would like to watch an example, here is a [recording of a teaching demo][demo-video].  
 
@@ -281,7 +291,7 @@ Best/Saludos,
 [trainer-minutes]: https://github.com/carpentries/trainers/tree/master/minutes
 [etherpad-template]: http://pad.software-carpentry.org/ttt-template
 [training-template]: https://github.com/carpentries/training-template
-[minute-cards-template]: https://docs.google.com/forms/d/1ZvNx2co9BLEBTzDavUE7ZkAhkekBa19_5aIRFAdQIqw/edit
+[minute-cards-template]: https://docs.google.com/forms/d/1p7iOV5HNvy4POS4g6eottY8RSfKq4kaoKz1-jIFYTMI/edit
 [checkout-checklist]: http://www.datacarpentry.org/checkout/
 [training-repo]: http://carpentries.github.io/instructor-training/
 [zoom-home]: https://www.zoom.us/


### PR DESCRIPTION
Includes
* space for new material (slides + whatever else comes up)
* links at the top for trainers
* changing the minute cards link to a true template
* indenting the online teaching recommendations more sanely.  

I don't know if the internal links are going to work.  