### PR TITLE
Overhaul notes to focus on workshops only

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -3,40 +3,13 @@ layout: page
 title: "Instructor Notes"
 permalink: /guide/
 ---
+Shortcuts to: 
+- Teaching Tips: [Online vs In Person](#-III.-Differences-Among-Training-Types), [Online Teaching](#-IV.-Zoom-Manual-(Online-Trainings)), [Curriculum Teaching Tips](#IIX.-Curriculum-Teaching-Tips)
 
-## I. Trainer Duties
-As of May 2017, the Trainers group adopted a
-[Trainer Agreement][trainer-agreement] outlining Trainer duties. Only active
-Trainers are voting members of the Trainer community. An inactive Trainer may
-re-activate their Trainer status at any time by resuming Trainer activities.
+## I. Information For and About Instructor Trainers
+Details about the Instructor Trainer role including the application process, duties, meetings, and administrative instructions are now housed in the [Carpentries Handbook][handbook]. To the extent that information in those instructions is directly pertinent to teaching an Instructor Training workshop, some items may be duplicated here. All other information previously housed on this page may now be found in the handbook.
 
-## II. Becoming a Trainer
-The Trainers group periodically accepts new members via application. New
-Trainers undergo an eight-week training program outlined in
-[the trainer process document][trainer-process] and
-agree to the [Trainer Agreement][trainer-agreement].
-
-## III. Trainer Meetings
-The Trainers group meets regularly. We have two types of meetings - business meetings, focused on
-discussing curricular and policy changes, and discussion meetings, where we share experiences and
-get advice about running instructor training events. Upcoming meetings are listed on [our Etherpad][trainer-pad]
-and on the [Community Calendar][community-calendar]. If you are not a Trainer, but are interested in joining a meeting,
-please contact Erin Becker (ebecker@carpentries.org). Minutes for these meetings [are available][trainer-minutes].
-
-## IV. Signing up to Teach an Instructor Training Event
-
-1. The Program Manager will send an email to the Trainers list asking all Trainers to fill in their calendar for the upcoming time period. Please sign up for as many days as you are available and hold those dates in your calendar until the schedule is confirmed.
-2. The Program Manager will confirm events with individual Trainers, at which point you are free to release all other dates on your calendar.
-3. Member sites will sign up for available dates. The Program Manager will let you know which sites you will be teaching as they sign up.
-4. If no member site signs up one month before the event, the event will become an open instructor training or be cancelled, depending on need.
-
-| For the months of... | Trainers will be asked for their availability on... | Trainers will be asked to fill out their availability by….| A confirmed calendar will be released by…. |
-| ----------------- | --------------- | -------------- | ------------ |
-| Jan/Feb/Mar/Apr   | Oct 6          | Oct 20          | Nov 1        |
-| May/June/July/Aug | Feb 15          | March 1        | April 1      |
-| Sept/Oct/Nov/Dec  | June 15         | July 1         | Aug 1        |
-
-## V. Running an Instructor Training Event (General)
+## II. Running an Instructor Training Event (General)
 
 ### Four weeks before the event
 -  Contact your co-Trainer(s) and decide who will teach what.  
@@ -46,29 +19,36 @@ please contact Erin Becker (ebecker@carpentries.org). Minutes for these meetings
 ### Two weeks before the event
 -  Introduce yourself to your trainees.  
 
-### One week before the event (if teaching remotely)   
--  Test videoconferencing set up with co-Trainer(s) using login credentials provided.   
--  Plan logistics with co-Trainer(s).  
--  Decide with co-Trainer(s) whether all Trainers should be present for the full event or if you will log on during your scheduled teaching times only.  
--  Make a copy of the [Virtual Minute Cards template][minute-cards-template] and personalize for your event.  
+### One week before the event    
+-  Plan logistics with co-Trainer(s)
+-  Review (or set aside time closer to the event to review) the pre-assessment survey results for your workshop
+-  If teaching remotely: 
+  -  Test videoconferencing set up with co-Trainer(s) using login credentials provided.   
+  -  Decide with co-Trainer(s) whether all Trainers should be present for the full event or if you will log on during your scheduled teaching times only.  
+  -  Make a copy of the [Virtual Minute Cards template][minute-cards-template] and personalize for your event.  
+-  If teaching in person:
+  - Confirm with your host that breakout rooms are available or make an alternate plan
+  - Create a plan for printing handouts & determine who will bring sticky notes
+  - Make sure you're prepared for the audiovisual setup in your room with the correct dongles/connectors etc.
+  - Check on availability/timing of coffee, lunch, or any other details that matter to you
 
 ### During the event
 -  Take attendance.  
--  Remind trainees to fill out application (member events only).   
+-  Remind member trainees to fill out application (Open Training applicants have already done this).   
 -  Remind trainees to sign up for demo, discussion (links in [checkout checklist][checkout-checklist]).  
 -  Monitor the Etherpad / Google Doc for questions and responses to exercises.  
 -  If teaching remotely: Turn off video during long exercises and coffee breaks and disconnect during lunch.  
 
 ### Immediately after the event
 -  Send a list of those who completed the training to checkout@carpentries.   
--  Send an email to trainees thanking them for participating and linking to [checkout checklist][checkout-checklist]. See template (below).  
+-  Send an email to trainees thanking them for participating and linking to [checkout checklist][checkout-checklist]. See template [here][post-template].  
 -  Review survey results and prepare to discuss at upcoming [Trainers discussion meeting][trainer-pad].  
 -  File any relevant issues or PRs to the [instructor training repo][training-repo].  
 
 ### Long-term after the event
 -  Join a [Trainer discussion meeting][trainer-pad] to discuss how your event went.   
 
-## VI. Differences Among Training Types
+## III. Differences Among Training Types
 
 ### In-person trainings
 - When watching videos, project them to the whole group.   
@@ -88,7 +68,7 @@ please contact Erin Becker (ebecker@carpentries.org). Minutes for these meetings
 - Have participants screen share with their breakout room during the live coding exercises.   
 - For exercise to set up a workshop website, put participants in breakout rooms and have one person screen share while the others help guide them verbally.  
 
-## VII. Zoom Manual (Online Trainings)
+## IV. Zoom Manual (Online Trainings)
 Online Carpentry Instructor Training events are held on [Zoom][zoom-home]. You can set up a personal Zoom
 account for yourself for free. This personal account will be able to attend the training event
 (or any other online Carpentry event), but will not be able to act as host.   
@@ -111,180 +91,53 @@ you’re not the host, please contact Carpentry staff immediately.
 
 ### General tips for online training:  
 - **Support the lead**
-- It's tempting to check-out and check email/do work when your co-teacher has taken the wheel.  Try not to do this!  Ways that you can support your co-teacher when they are leading are: 
-  - Monitor the chat in zoom/notes
-  - Help post exercises + provide instructions
-  - Find links or references
-- Make sure that whomever is actively teaching always has host privileges. When you take turns instructing, remember to hand-off host privileges during the change-over.
+	- It's tempting to check-out and check email/do work when your co-teacher has taken the wheel.  Try not to do this!  Ways that you can support your co-teacher when they are leading are: 
+	  - Monitor the chat in zoom/notes
+	  - Help post exercises + provide instructions
+	  - Find links or references
+	- Make sure that whomever is actively teaching always has host privileges. When you take turns instructing, remember to hand-off host privileges during the change-over.
 - **Exercise management**
-- After the first exercise, keep a list of all the participants in a plain text file on your computer so can you can easily paste it into the shared note-taking doc for exercises. (G.W.)
-- Screen-share a timer/countdown clock (like [this timer from timeanddate.com](https://www.timeanddate.com/timer/)) so participants know how long they have to work on exercises. (L.N)
+  - After the first exercise, keep a list of all the participants in a plain text file on your computer so can you can easily paste it into the shared note-taking doc for exercises. (G.W.)
+  - Screen-share a timer/countdown clock (like [this timer from timeanddate.com](https://www.timeanddate.com/timer/)) so participants know how long they have to work on exercises. (L.N)
 - **Zoom tips**
-- “Gallery view” in the upper right toggles the display to show more participants' videos.  
-- “Share screen” is at the bottom middle of the screen. To end “share screen”, click the red button that will appear at the top middle of the screen when you are in screen sharing mode.  
-- When you screen share, you have the option to share individual apps or your entire desktop. The default is the full desktop.
-- The Zoom chat is not stable (it is not saved across sessions or after going into breakout rooms, and people who have just joined a room can't see previously posted chat items). We highly recommend using the Etherpad or Google Doc chat instead. For those who want to save the chat, they do that using the "More" option in the chat window, which offers "Save chat". Choosing this will save the chat to a local text file on the person's computer.
-- During breaks, learners will often turn off their video and wait for your audio cue to re-activate. This makes it look like no one is back from break, but just saying 'hello' will generally get a bunch of people to come back on video quickly.
-- When several attendees are in the same room (member trainings): it is helpful to have every participant log in separately so that you can see names and faces and they can interact by waving or using the chat. However, it is important that only one microphone and speaker should be active in the room at one time or feedback and noise will be a problem. When creating breakouts, you can either leave these people in the main room or shuffle people around to create a room just for them. Either way, ask them to leave a mic on so you can listen in.
-- Attendees might like to have a separate room (without Trainers) to network in over lunch or other breaks. Be prepared to assign that room and then close it to restart the main session.
+  - “Gallery view” in the upper right toggles the display to show more participants' videos.  
+  - “Share screen” is at the bottom middle of the screen. To end “share screen”, click the red button that will appear at the top middle of the screen when you are in screen sharing mode.  
+  - When you screen share, you have the option to share individual apps or your entire desktop. The default is the full desktop.
+  - The Zoom chat is not stable (it is not saved across sessions or after going into breakout rooms, and people who have just joined a room can't see previously posted chat items). We highly recommend using the Etherpad or Google Doc chat instead. For those who want to save the chat, they do that using the "More" option in the chat window, which offers "Save chat". Choosing this will save the chat to a local text file on the person's computer.
+  - During breaks, learners will often turn off their video and wait for your audio cue to re-activate. This makes it look like no one is back from break, but just saying 'hello' will generally get a bunch of people to come back on video quickly.
+  - When several attendees are in the same room (member trainings): it is helpful to have every participant log in separately so that you can see names and faces and they can interact by waving or using the chat. However, it is important that only one microphone and speaker should be active in the room at one time or feedback and noise will be a problem. When creating breakouts, you can either leave these people in the main room or shuffle people around to create a room just for them. Either way, ask them to leave a mic on so you can listen in.
+  - Attendees might like to have a separate room (without Trainers) to network in over lunch or other breaks. Be prepared to assign that room and then close it to restart the main session.
 
-## IIX. Running a Teaching Demonstration  
+## V. Curriculum Teaching Tips
+This is a place for Trainers to leave tips and observations for those newer to the curriculum. This can provide guidance on how to navigate difficult places in the curriculum until problems can be fixed, or may provide additional instructions that are conditional to an audience or are otherwise not appropriate to/ready for a change in the curriculum itself.
 
-If you would like to watch an example, here is a [recording of a teaching demo][demo-video].  
+### Welcome	
+### How Learning Works: The Importance of Practice 
+### How Learning Works: Expertise and Instruction	
+### How Learning Works: Working Memory and Cognitive Load	
+### Building Teaching Skill: Getting Feedback	
+### Creating a Positive Learning Environment: Mindset
+### Building Teaching Skill: The Importance of Practice	
+### Wrap-Up and Homework for Tomorrow	
+### Welcome Back	
+### Building Teaching Skill: Lesson Study	
+### Building Teaching Skill: Live Coding	
+### Building Teaching Skill: Performance Revised	
+### The Carpentries: Workshop Introductions	
+### The Carpentries: How We Operate	
+### The Carpentries: Teaching Practices
+### Afternoon Wrap-Up	
 
-### Before the demo
--  Sign up to [lead demos][demo-pad].  
--  A day or two before the demo, send a reminder email, see the template (below).
--  For each trainee, pick a suitable starting point in the lesson that they have chosen. For most lessons, any episode will be suitable. There are a few exceptions - listed below. Do not have them start in the middle of an episode. Note that some lessons (e.g., the Software Carpentry R lesson using inflammation data) have supplementary episodes. Do not pick from those.  
-
-### Shortly Before the Demo
--  Go to the Zoom room. The link is in the [Etherpad][demo-pad].    
--  Once everyone is in the call (audio and video working), remind them of the Code of Conduct, explain the procedure for the demo session, and remind them that trainees have to be able to teach from any episode from their chosen lesson. Ask whether anyone has only prepared for 5 minutes from one episode instead of the entire lesson, and if so, suggest strongly they reschedule.    
--  Ask those not presenting to mute their microphone, and tell them they are to give feedback in the Etherpad using the same positive-vs-negative and content-vs-presentation rubric used in training.    
--  Hand out the assignment to the first trainee, give them a bit of time to set up the demo (they may have to import some packages, load some data, move to a certain folder etc).  
--  Ask them to share their screen using the “Share Screen” lower menu in Zoom.  
--  Once they are ready, give them a 3-2-1 countdown to start.  
--  Use a countdown timer which makes a noise once their 5 minutes are up (e.g., your phone), or just say “bong” really loudly at the end of their time.  
--  After the five minute timer, allow them to finish their sentence and tell them time’s up.
--  Use a [rubric][demo-rubric] for notes.   
--  After the trainee is finished, first ask how they themselves thought it went, then give constructive feedback based on your notes.  
--  Do NOT tell a trainee whether they passed immediately after their demo.   
--  Repeat for the other trainees.  
--  At the end of the season, ask for general questions.  
--  If all of your trainees passed, you can tell the group at the end of the demo session. If anyone did not pass, tell everyone you will send them each an email to let them know if they passed.  
-
-### After the Demo
--  Email checkout@carpentries.org with names, pass/fail, and SWC/DC for each of your trainees.  
--  Clear Etherpad of data from your session.  
--  If you had any “fails”, send that trainee an email letting them know the reason they did not pass and asking them to retry. See template (below).  
-
-### Not Good Starting Points for Demos
-Any episode other than those listed below should make an okay starting point for a teaching demonstration.
-
-*  SWC
-   *  [The Unix Shell 01-intro]({{ site.swc_pages }}/shell-novice/01-intro/) - no live coding
-   *  [Version Control with Git 01-basics]({{ site.swc_pages }}/git-novice/01-basics/) - no live coding
-   *  Version Control with Git - anything after [Tracking Changes]({{ site.swc_pages }}/git-novice/04-changes/) - dependencies
-   *  [Version Control with Mercurial]({{ site.swc_pages }}/hg-novice/01-basics/) - no live coding
-   *  Version Control with Mercurial - anything after [Configuring Mercurial]({{ site.swc_pages }}/hg-novice/02-configuration/) - dependencies
-   *  [Databases and SQL 08-hygiene]({{ site.swc_pages }}/sql-novice-survey/08-hygiene/) - no live coding
-   *  [Programming with Python 09-debugging]({{ site.swc_pages }}/python-novice-inflammation/09-debugging/) - no live coding
-   *  [R for Reproducible Scientific Analysis 16-wrap-up]({{ site.swc_pages }}/r-novice-gapminder/16-wrap-up/) - no live coding
-   *  Automation and Make - anything after [Makefiles]({{ site.swc_pages }}/make-novice/02-makefiles/) - dependencies
-
-*  DC (stable lessons only)
-  * Open Refine for Ecology - anything after [Working with OpenRefine]({{ site.dc_site }}/OpenRefine-ecology-lesson/01-working-with-openrefine/) - dependencies
-  * [SQL for Ecology]({{ site.dc_site }}/sql-ecology-lesson/00-sql-introduction/) - live coding doesn't start until middle of episode
-  * [R for Ecology]({{ site.dc_site }}/R-ecology-lesson/00-before-we-start.html) - no live coding
-  * R for Ecology - anything after [Manipulating data frames]({{ site.dc_site }}/R-ecology-lesson/03-dplyr.html) - dependencies
-  * Python for Ecology - anything after [Data workflows and automation]({{ site.dc_site }}/python-ecology-lesson/06-loops-and-functions/) - dependencies
-
-*  LC (stable lessons only)
-  * Anything in [Data Intro for Librarians](https://librarycarpentry.github.io/lc-data-intro/) - no live coding
-  * [OpenRefine 01-introduction](https://librarycarpentry.github.io/lc-open-refine/01-introduction/) - no live coding
-  * OpenRefine - anything after [Layout of OpenRefine, Rows vs Records](https://librarycarpentry.github.io/lc-open-refine/03-working-with-data/) - dependencies
-
-## IX. Email Templates
-
-### Reminder teaching demo
-
-Subject: Software/Data Carpentry teaching demonstration
-
-Hi,
-
-According to http://pad.software-carpentry.org/teaching-demos you have signed up to give an online teaching demo on [date] at [time] (See this link for your local time: [timeanddate.com link]). I will be the Instructor Trainer running the session.
-
-I wanted to make it very clear that I may give you any segment of the lesson you prepared to teach, so you must be ready to teach any part of your chosen lesson. Some people prepare to teach 5 minutes from a particular section and nothing else, and these often have to reschedule as they seldom are assigned the section they have prepared for. A lesson corresponds to a single line in the lesson tables (https://software-carpentry.org/lessons/ and http://www.datacarpentry.org/lessons/) and a single repository on GitHub. Some lessons have supplementary modules, but you do not need to be prepared to teach the supplementary modules for your teaching demonstration.
-
-For example, if you have chosen The Unix Shell, I may assign you any episode listed at http://swcarpentry.github.io/shell-novice/.
-
-Please visit the Etherpad a little while before the demo starts, I will post a link there to another Etherpad we will be using for this demo.
-
-See you at the demo session,
-[ name ]
-
-### Trainee didn’t pass teaching demo
-
-Hi [ name ],
-
-Thank you for doing a teaching demonstration. While you demonstrated good command of the
-subject material, I’ve determined not to pass you based on [ reason ] .
-[ Explanation of this reason. ]  We are excited about having you as a Carpentry instructor and
-I would be happy to see you do another teaching demonstration [ making these changes ] to
-certify as an instructor.
-
-Please let me know if you have any questions.
-
-Best wishes,
-[ name ]
-
-### Trainee did pass teaching demo
-
-Hi [ name ],
-
-I’m happy to tell you that you have passed your teaching demonstration! You demonstrated good
-command of the subject material and a solid understanding of Carpentry teaching methods. We
-are excited about having you as a Carpentry instructor. I’ve forward this information to our
-staff. If this was the last stage in your instructor training checkout, you should get your
-official Carpentry Instructor certificate in about a week, along with instructions for signing
-up to teach workshops. If you still have steps remaining in your checkout, please be sure to
-complete them before your deadline. If you have any questions, please email
-checkout@carpentries.org.
-
-Welcome to the Carpentry Instructor community!
-
-Best wishes,
-[ name ]
-
-### Email after training event
-
-Hi everyone,
-
-Thank you for participating in our Carpentry Instructor training workshop. We really enjoyed
-having you involved and getting to know you a bit. You are now well on your way towards
-becoming a certified Carpentry instructor!
-
-If you did not get a chance to complete the post-workshop survey, please take a moment to do so [here](https://www.surveymonkey.com/r/post-instructor-training). We actively use these data to improve our workshops for future learners.
-
-In order to finish your certification, please finish the tasks listed on [the checkout checklist][checkout-checklist] by the
-90-day deadline. If you have any questions about the checkout process, please contact checkout@carpentries.org.
-
-Looking forward to having you as a Carpentry Instructor!
-
-Best,
-[ name ]
+### Using Slides
+### General Preparation
 
 
-### Bilingual Demo Session Reminder Email
 
-Hello,
-
-Thanks for signing up to complete your “Teaching Demo” as part of the instructor certification process.  We will meet tomorrow at *Insert Time* in a [Zoom meeting room](https://carpentries.zoom.us/j/357144246). Please read this short bi-lingual description of [How Teaching Demo session works](https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md). Disclaimer: I understand Spanish better than I speak it. So, I will talk in Spanish as much as I can, but I will most likely give feedback about your teaching in English.
-
-Please let me know if you have any questions or concerns.
-
-Hola,
-
-Gracias por inscribirte para completar tu "Demostración de enseñanza" como parte del proceso de certificación para instructores. Nos reuniremos mañana *Insert Time* [aquí](https://carpentries.zoom.us/j/357144246). Por favor, lee ésta breve descripción bilingüe de cómo funciona la sesión de demostración de enseñanza [aquí](https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md). Aviso: Entiendo el español mejor de lo que hablo. Por lo tanto, voy a hablar en español un poco, pero es muy probable que les dé comentarios sobre su enseñanza en Inglés.
-
-Por favor, hágamelo saber si tiene alguna pregunta o inquietud.
-
-Best/Saludos,
-
-[ name ]
-
-
-[trainer-agreement]: https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html
-[trainer-process]: https://docs.google.com/document/d/14Zi_W9uk1wua2v3zy8um6oMCnvO41Qfo1KwStCA-hos/edit
-[trainer-pad]: http://pad.software-carpentry.org/trainers
-[community-calendar]: http://pad.software-carpentry.org/trainers
-[trainer-minutes]: https://github.com/carpentries/trainers/tree/master/minutes
+[handbook]: https://docs.carpentries.org/topic_folders/instructor_training/index.html#for-trainers
+[post-template]: https://docs.carpentries.org/topic_folders/instructor_training/email_templates_trainers.html#email-after-training-event
 [etherpad-template]: http://pad.software-carpentry.org/ttt-template
 [training-template]: https://github.com/carpentries/training-template
-[minute-cards-template]: https://docs.google.com/forms/d/1ZvNx2co9BLEBTzDavUE7ZkAhkekBa19_5aIRFAdQIqw/edit
+[minute-cards-template]: https://docs.google.com/forms/d/1p7iOV5HNvy4POS4g6eottY8RSfKq4kaoKz1-jIFYTMI/edit
 [checkout-checklist]: http://www.datacarpentry.org/checkout/
 [training-repo]: http://carpentries.github.io/instructor-training/
 [zoom-home]: https://www.zoom.us/
-[demo-video]: https://www.youtube.com/watch?v=FFO2cq-3PPg
-[demo-pad]: http://pad.software-carpentry.org/teaching-demos
-[demo-rubric]: https://github.com/carpentries/instructor-training/blob/gh-pages/files/teaching-demo-rubric.md


### PR DESCRIPTION
Because all of the information here has been duplicated in the Handbook, these notes are now free to focus exclusively on details that are necessary or helpful in preparing for an Instructor Training workshop.  This PR establishes a new structure for this page -- will fill in Curriculum Teaching Tips section after any restructuring associated with the current update is complete.

This also incorporates several changes proposed in https://github.com/carpentries/instructor-training/pull/714 and is intended as a replacement for that PR.


