### PR TITLE
add lesson for encouraging ongoing learning

### DIFF
--- a/_episodes/26-continued-learning.md
+++ b/_episodes/26-continued-learning.md
@@ -1,0 +1,118 @@
+---
+title: "Encouraging Ongoing Learning"
+block: "The Carpentries"
+teaching: 10
+exercises: 30
+questions:
+- "How do you set learners up for post-workshop success"
+objectives:
+- "Identify resources at host institution for ongoing support."
+- "Help workshop host develop as plan for ongoing learning opportunities."
+keypoints:
+- "Resources may be available at host institution."
+- "Learner-led groups can aid long-term."
+---
+
+The drawback of any fast-paced workshop is the danger that
+information will never be solidified in long-term memory. We try to mitigate
+this by tying concepts together across lessons (i.e. using Unix commands in the
+Git lesson, or functions in python and R), but the problem remains. Here, we aim
+to give some ideas for encouraging ongoing learning at the institution.
+
+This is a complicated problem to address, as the instructor typically has
+little contact with the institution after the workshop apart from surveys.
+
+
+## Before the workshop
+
+> ## Your Academic Past
+>
+> Think back to courses or workshops you really liked or didn't like.
+> - How did those courses start?
+> - Were you confident in the instructors abilities?
+> - Did you feel like they were enthusiastic about the course and invested in you?
+> - Was it clear what you were going to be learning?
+> - Were you excited about the material?
+> - Did you leave that first day thinking the instructor was uninterested, that you weren't the learners they wanted to
+be teaching or you had no idea what the course was supposed to be about?
+{: .discussion}
+
+When working with the organizers, have a conversation about plans for ongoing learning.
+You might ask some of the following questions:
+- Is there a computer or data science society at the local college or university?
+- Does the local library host any research computing activities?
+- Does the host city have a related Meetup gathering?
+
+If the workshop is being held at a university or research institute,
+there may be people with expertise who would be willing to assist learners.
+Ask the host to consider reaching out to them. They may already have while
+identifying possible workshop helpers.
+
+## During the workshop
+
+Take some time to meet with the host, organizers, and helpers. While you cannot
+be there to help with the ongoing learning, now is the time to
+convey a bit of the Carpentries ethos.  Explain some of the challenges
+that will be facing the learners after the workshop, and encourage them
+to brainstorm about the most efficient means of post-workshop support.
+For some, that could mean starting a Hacky Hour group, where learners meet
+on a weekly or bi-weekly basis to apply software carpentry skills to their
+own research, help each other on a particular problem.  For other groups, it
+may make more sense to partner with an existing effort.
+
+Towards the end of the workshop, address the learners. Let them know that the main
+challenge they will face moving ahead with these skills is remembering
+all that was contained in the workshop. The workshop is designed to
+empower learners to  make their research easier and more effective. This
+confidence will wane with time if the skills are not used, and it is all
+too easy to let newly-learned skills fall by the wayside.  Remind the
+students of all they accomplished over the last two days; reiterate where
+the lesson materials can be found, and encourage them to apply
+at least one of the skill to their own work within the next few days.  Some examples could be:
+
+- Recreate an Excel chart from a past presentation in R
+- Write a lab notebook entry in R-markdown
+- Backup a thesis or manuscript by storing it on a version control server
+- Log in to a remote machine and run an analysis there
+
+
+> ## What was your first?
+>
+> Get into small groups (3-4 people) and discuss the first time you used
+> one of the skills taught in one of the Lessons.
+>
+> 1. What helped you transition from the "old way"?
+> 2. What challenges did you have to address when implementing the new skills?
+> 3. How did you overcome those challenges?
+>
+> After 5 minutes, come together, and combine ideas as a large group.
+>
+> Finally, compare your ideas with the list of topics below.  Did you miss anything?
+> Did you come up with something that's not listed below?
+>
+{: .discussion}
+
+## Challenges to Ongoing Learning
+
+We already discussed the primary challenge: solidifying skills in long-term memory.
+Other challenges exist as well. Isolation is a major challenge --  in
+the workshops, learners are never far from a helper or a peer that can
+help them find that missing bracket. Further, learners may feel less
+competent because they can only see their struggled, not a room full
+of red stickies on their peers computers.
+
+Another challenge may be that the time allotted by supervisors may not be
+enough to encourage exploring a new way of doing things (even if the
+new way could save many hours in the long run).
+
+## Resources for Stating  a Hacky Hour
+
+Amanda Miotto's [Hacky Hour Handbook](https://github.com/amandamiotto/HackyHourHandbook/blob/master/Introduction.md)
+is a great resource for hosts.  This includes detailed information on how to
+start a successful Hacky Hour to both support learners and allow them
+to share their newfound knowledge.
+
+## Other Resources
+
+- [Rachel Handscombe's "Encouraging students to develop lifelong learning"](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2991754/)
+- [Chloe Hwang's "Life after Coding Bootcamp"](https://www.viget.com/articles/life-after-coding-bootcamp-starting-my-first-job/)


### PR DESCRIPTION
Hi all!  I realize that the guidelines warn against submitting new lessons, but I think it would be worth discussing how to encourage post-workshop learning. This likely has been discussed extensively on some Etherpad or during some meeting. Here, I have outlined how I addressed some of the struggles that I had post-workshop and getting started in bioinformatics, with hopes that other community members might contribute what works for them as well.  

There is lots of support for how to host a workshop on the carpentries websites, but not much by way of supporting attendees after the workshop.  If this is deemed the wrong place to discuss post-workshop operations, perhaps some of this material could be incorporated there?

I wrote this as lesson 26, which could be used optionally if the instructor training has time.  Alternatively, some of the material could be incorporated into the earlier pedagogy lessons.

Any insight would be appreciated!