### PR TITLE
Remove "code-along" from live coding exercise 

### DIFF
--- a/_episodes/14-live.md
+++ b/_episodes/14-live.md
@@ -153,10 +153,6 @@ Remind learners frequently about using their sticky notes, or they (and you) wil
 > using the 2x2 rubric we discussed previously and enter the feedback
 > you received in the Etherpad.
 >
-> To make this exercise as similar to the workshop experience as possible,
-> ask your fellow trainees to code along with you, as if they were learners at your
-> workshop.
->
 > This exercise should take about 25 minutes.  
 {: .challenge}
 


### PR DESCRIPTION
we don't actually do this.

Closes issue #840


