### PR TITLE
Change activity order in Management

### DIFF
--- a/_episodes/18-management.md
+++ b/_episodes/18-management.md
@@ -15,6 +15,99 @@ keypoints:
 - "Response to a Code-of-Conduct violation at a workshop is subject to instructor discretion, but all violations should be reported to the Carpentries for follow-up."
 
 ---
+## Managing a Diverse Classroom
+
+Although our workshops are targeted at novices, every workshop
+will have participants from a variety of backgrounds and technical
+skill levels. Some may be at the novice level in one technology (e.g. git),
+but competent or even expert in another (e.g. R). As an instructor,
+you will need to be attentive to this diversity in your learners' prior skill level,
+and adjust your instruction appropriately. This is one of the most difficult things
+instructors experience when running a workshop.
+
+> ## What Are the Challenges?
+> What are some of the challenges you might expect when teaching learners with a broad range of expertise? Discuss with
+> a partner and put your thoughts in the Etherpad.
+>
+> This discussion should take about 10 minutes.
+{: .challenge}
+
+Here are some strategies Carpentries
+instructors have generated to deal with this issue:
+
+*   Before running a workshop,
+    communicate its level clearly to everyone who's thinking of signing up
+    by describing not only the topics that will be covered (e.g. plotting in R), but
+    also the concrete skills that learners will have after the workshop (i.e. the learning objectives).
+    If you're upfront with participants that you'll be spending time learning how `for` loops work, more
+    advanced learners are less likely to sign up.
+*   When asking learners to complete exercises, give "beginner" and "advanced" options.
+    Learners who finish the "beginner" exercise can then challenge themselves and don't get bored.
+*   Ask more advanced learners to help people next to them.
+    They'll learn from answering their peers' questions
+    (since it will force them to think about things in new ways).
+*   Take care not to let enthusiastic advanced learners carry the conversation, as this tends to alienate novices
+    and consumes valuable class time. Advanced questions and discussion can be politely reserved for breaks or dealt
+    with by helpers or the co-instructor in the Etherpad.
+*   The helpers and the instructor who isn't teaching the particular episode
+    should keep an eye out for learners who are falling behind
+    and intervene early
+    so that they don't become frustrated and give up.
+
+The most important thing is to accept that
+no class can possibly meet everyone's individual needs.
+If the instructor slows down to accommodate two people who are struggling,
+the other 38 are not being well served.
+Equally,
+if she spends a few minutes talking about an advanced topic because two learners are bored,
+the 38 who don't understand it will feel left out.
+All we can do is tell our learners what we're doing and why,
+and hope that they'll understand.
+
+
+> ## Learners Use Their Own Machines
+> Learners tell us that it is important to them to leave the workshop
+> with their own machine set up to do real work.  We therefore continue
+> to teach on all three major platforms (Linux, Mac OS X, and Windows),
+> even though it would be simpler to require learners to use just one.
+>
+> We have experimented with virtual machines (VMs) on learners'
+> computers to reduce installation problems, but those introduce
+> problems of their own: older or smaller machines simply aren't fast
+> enough, and learners often struggle to switch back and forth between
+> two different sets of keyboard shortcuts for things like copying and
+> pasting.
+>
+> Some instructors use [Virtual Private Servers][vps] (VPS) over [Secure Shell][ssh]
+> (SSH) or web browser pages instead. This solves the installation
+> issues, but makes us dependent on host institutions' WiFi (which can be
+> of highly variable quality), and has the issues mentioned above with things
+> like keyboard shortcuts.
+{: .callout}
+
+## Code of Conduct Violations
+
+If you are an instructor, and believe that someone in a workshop has
+violated the Code of Conduct, you may warn them, ask them to
+apologize, and/or expel them, depending on the severity of the
+violation and whether or not you believe it was intentional.
+
+The local workshop host is expected to help enforce the Code of Conduct and
+you can ask them to mediate an incident if you are uncomfortable or unable to do so yourself.
+If you choose to settle the issue yourself, you should notify the workshop host
+of the issue in case s/he feels additional steps should be taken.
+
+No matter what you choose to do, please contact the Carpentries Code of Conduct Committee by emailing [coc@carpentries.org](mailto:coc@carpentries.org)
+or C. MacDonnell at [confidential@carpentries.org](mailto:confidential@carpentries.org)
+as soon as you can and let us know what happened so that we can follow-up
+with the workshop host and/or participants as needed.
+
+You also have the right as an instructor to walk out of a workshop
+if you feel that the participants or hosts are not supporting your
+attempts to enforce the Code of Conduct. Again, please contact us
+as soon as possible if this happens.
+
+
 ## Never Teach Alone: How to Be a Co-instructor
 
 The best thing about managing a classroom for a Carpentries workshop is that you never face problems alone! Your co-instructor, helpers, and host are all there for you.
@@ -133,100 +226,6 @@ no-one will understand how pleased you are at helping someone
 understand how loops work, or how disappointed you are that you just
 couldn't get software to install on that one learner's laptop, than
 the person you just taught with.
-
-
-
-## Managing a Diverse Classroom
-
-Although our workshops are targeted at novices, every workshop
-will have participants from a variety of backgrounds and technical
-skill levels. Some may be at the novice level in one technology (e.g. git),
-but competent or even expert in another (e.g. R). As an instructor,
-you will need to be attentive to this diversity in your learners' prior skill level,
-and adjust your instruction appropriately. This is one of the most difficult things
-instructors experience when running a workshop.
-
-> ## What Are the Challenges?
-> What are some of the challenges you might expect when teaching learners with a broad range of expertise? Discuss with
-> a partner and put your thoughts in the Etherpad.
->
-> This discussion should take about 10 minutes.
-{: .challenge}
-
-Here are some strategies Carpentries
-instructors have generated to deal with this issue:
-
-*   Before running a workshop,
-    communicate its level clearly to everyone who's thinking of signing up
-    by describing not only the topics that will be covered (e.g. plotting in R), but
-    also the concrete skills that learners will have after the workshop (i.e. the learning objectives).
-    If you're upfront with participants that you'll be spending time learning how `for` loops work, more
-    advanced learners are less likely to sign up.
-*   When asking learners to complete exercises, give "beginner" and "advanced" options.
-    Learners who finish the "beginner" exercise can then challenge themselves and don't get bored.
-*   Ask more advanced learners to help people next to them.
-    They'll learn from answering their peers' questions
-    (since it will force them to think about things in new ways).
-*   Take care not to let enthusiastic advanced learners carry the conversation, as this tends to alienate novices
-    and consumes valuable class time. Advanced questions and discussion can be politely reserved for breaks or dealt
-    with by helpers or the co-instructor in the Etherpad.
-*   The helpers and the instructor who isn't teaching the particular episode
-    should keep an eye out for learners who are falling behind
-    and intervene early
-    so that they don't become frustrated and give up.
-
-The most important thing is to accept that
-no class can possibly meet everyone's individual needs.
-If the instructor slows down to accommodate two people who are struggling,
-the other 38 are not being well served.
-Equally,
-if she spends a few minutes talking about an advanced topic because two learners are bored,
-the 38 who don't understand it will feel left out.
-All we can do is tell our learners what we're doing and why,
-and hope that they'll understand.
-
-
-> ## Learners Use Their Own Machines
-> Learners tell us that it is important to them to leave the workshop
-> with their own machine set up to do real work.  We therefore continue
-> to teach on all three major platforms (Linux, Mac OS X, and Windows),
-> even though it would be simpler to require learners to use just one.
->
-> We have experimented with virtual machines (VMs) on learners'
-> computers to reduce installation problems, but those introduce
-> problems of their own: older or smaller machines simply aren't fast
-> enough, and learners often struggle to switch back and forth between
-> two different sets of keyboard shortcuts for things like copying and
-> pasting.
->
-> Some instructors use [Virtual Private Servers][vps] (VPS) over [Secure Shell][ssh]
-> (SSH) or web browser pages instead. This solves the installation
-> issues, but makes us dependent on host institutions' WiFi (which can be
-> of highly variable quality), and has the issues mentioned above with things
-> like keyboard shortcuts.
-{: .callout}
-
-## Code of Conduct Violations
-
-If you are an instructor, and believe that someone in a workshop has
-violated the Code of Conduct, you may warn them, ask them to
-apologize, and/or expel them, depending on the severity of the
-violation and whether or not you believe it was intentional.
-
-The local workshop host is expected to help enforce the Code of Conduct and
-you can ask them to mediate an incident if you are uncomfortable or unable to do so yourself.
-If you choose to settle the issue yourself, you should notify the workshop host
-of the issue in case s/he feels additional steps should be taken.
-
-No matter what you choose to do, please contact the Carpentries Code of Conduct Committee by emailing [coc@carpentries.org](mailto:coc@carpentries.org)
-or C. MacDonnell at [confidential@carpentries.org](mailto:confidential@carpentries.org)
-as soon as you can and let us know what happened so that we can follow-up
-with the workshop host and/or participants as needed.
-
-You also have the right as an instructor to walk out of a workshop
-if you feel that the participants or hosts are not supporting your
-attempts to enforce the Code of Conduct. Again, please contact us
-as soon as possible if this happens.
 
 
 


### PR DESCRIPTION
Existing order creates a major problem with CoC discussion last -- it ends up crunched for time and leaves everybody on edge as they head off to lunch. This PR moves management challenges and CoC up to come before co-instruction. This allows both of these topics to carry forward into conversations about co-instruction, and leaves an easier choice for cutting content to get to lunch on time.


