### PR TITLE
update link to chicago tribune paper

### DIFF
--- a/_episodes/03-expertise.md
+++ b/_episodes/03-expertise.md
@@ -242,5 +242,5 @@ motivations, making it easier for you to target your lesson materials to their n
 you as an instructor overcome your expert blind spot. It doesn't matter how easy you think a task is, if your
 learners aren't getting it, it's probably more complicated than you thought.
 
-[motivation-words]: http://www.chicagotribune.com/bluesky/hub/ct-buffer-words-and-phrases-that-motivate-bsi-hub-20160225-story.html
+[motivation-words]: https://perma.cc/LE2H-VWXG?type=image
 [four-letter-words]: https://signalvnoise.com/posts/439-four-letter-words


### PR DESCRIPTION
added the perma link suggested here: https://github.com/carpentries/instructor-training/issues/888#issuecomment-465354657. closes #888