### PR TITLE
Removed lesson program language from heading

### DIFF
--- a/_episodes/15-lesson-study.md
+++ b/_episodes/15-lesson-study.md
@@ -110,7 +110,7 @@ guiding them to look ahead to where we might not be able to take them.
 
 Image credit: Vanderbilt University Center for Teaching
 
-> ## Evaluate SWC and DC Learning Objectives
+> ## Evaluate Learning Objectives
 >
 > Your instructor has posted links to a handful of current Carpentries lessons in the Etherpad.
 > Select one learning objective from one of those lessons,


### PR DESCRIPTION
Heading included SWC and DC. Removed so that it says *Evaluate Learning Objectives* rather than *Evaluate SWC and DC Learning Objectives*.


