### PR TITLE
Add error framing definition to mindset episode

### DIFF
--- a/_episodes/09-mindset.md
+++ b/_episodes/09-mindset.md
@@ -109,7 +109,7 @@ highlighting our ability to improve with effort.
 {: .quotation}
 
 One of the barriers to learning is avoidance of making errors. Errors are associated with negative emotions, which leads to learners being 
-fearful of making them. *Error framing* encourages learners to understand that making errors provides valuable learning opportunities instead 
+fearful of making them. *Error framing* is the process of presenting errors as an integral part of the learning process and using them as teaching opportunities. Error framing encourages learners to understand that making errors provides valuable learning opportunities instead 
 of having negative consequences. For example, the [Language Acquisition Made Practical](http://www.worldcat.org/title/language-acquisition-made-practical-field-methods-for-language-learners/oclc/935845446?referer=di&ht=edition) (LAMP)
 system for learning language encourages learners to develop phrases and try them in a variety of social situations with native speakers. By 
 being willing to make mistakes, LAMP learners receive useful feedback from native speakers in real-world social situations. Error framing has 


### PR DESCRIPTION
In issue https://github.com/carpentries/instructor-training/issues/892, @gcapes notes that error framing is not defined or explained. I tried to google a definition of error framing, but I could not find a website with a definition. There is a brief definition in [our glossary](https://carpentries.github.io/instructor-training/glossary/index.html), so I added that sentence into the lesson. 

Maybe someone has a reference to add? @ErinBecker @karenword ?