### PR TITLE
add note about flash to guide

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -189,6 +189,9 @@ learners a full 60 minutes for lunch and 15-20 minutes for the morning/afternoon
 ### Building Skill with Practice
 ### Expertise and Instruction	
 ### Memory and Cognitive Load	
+
+* FM and RH: The [online tool](http://cat.xula.edu/thinker/memory/working/serial) we use to test working memory requires Flash. There is a verbal exercise you can use if Flash does not work for you.
+
 ### Building Skill with Feedback	
 ### Motivation and Demotivation
 


### PR DESCRIPTION
Given the discussion in https://github.com/carpentries/instructor-training/issues/540, this PR adds a note about flash not working for everyone. 

(I meant to include this with my change in https://github.com/carpentries/instructor-training/pull/915, but my github skills are not cooperating today). 