### PR TITLE
Fix typos; standardize capitalization of GitHub and Etherpad.

### DIFF
--- a/_episodes/09-mindset.md
+++ b/_episodes/09-mindset.md
@@ -54,7 +54,7 @@ and receive feedback, which, [as we've discussed]({{ page.root }}/02-practice-le
 > Pair: Discuss your thoughts about the influence of mindset in a workshop. Try to come up with a few different ways or
 > situations in which mindset might be relevant.
 > 
-> Share: A few thoughts in the etherpad (or go around the room and discuss)
+> Share: A few thoughts in the Etherpad (or go around the room and discuss)
 > 
 > This exercise should take about 5 minutes. 
 {: .challenge}

--- a/_episodes/13-second-welcome.md
+++ b/_episodes/13-second-welcome.md
@@ -27,7 +27,7 @@ about workshop logistics that will help you in preparing to teach your first wor
 > ## Questions
 > 
 > Yesterday we asked you to read some resources about the logistics of teaching and running Carpentries workshops. Please 
-> add your questions about logistics and preparation to the Etherpad. We will answer these questions in the etherpad during your work time
+> add your questions about logistics and preparation to the Etherpad. We will answer these questions in the Etherpad during your work time
 > and will return to this list later today.
 > 
 > This activity should take about 5 minutes.

--- a/_episodes/20-checkout.md
+++ b/_episodes/20-checkout.md
@@ -37,7 +37,7 @@ As you read in your homework last night, there are three final steps to complete
 
 > ## Checking Out Review with Questions and Answers
 > 
-> In small groups, read and discuss one of the three checkout procedures listed above and described in detail at [This page]({{ page.root }}/checkout/). Make notes in the etherpad and when you're done, report back to the full group about the requirements for that stage of the process. What questions do you still have about the checkout process? 
+> In small groups, read and discuss one of the three checkout procedures listed above and described in detail at [This page]({{ page.root }}/checkout/). Make notes in the Etherpad and when you're done, report back to the full group about the requirements for that stage of the process. What questions do you still have about the checkout process?
 > 
 > This exercise should take about 5 minutes.
 {: .challenge}

--- a/_episodes/21-carpentries.md
+++ b/_episodes/21-carpentries.md
@@ -82,7 +82,7 @@ Data Carpentry workshops:
 
 Library Carpentry workshops: 
 
-*   are aimed at people in library- and information-related roles.
+*   are aimed at people in library- and information-related roles,
 *   focus on best practices in data structure, and
 *   are modular---each Library Carpentry lesson is standalone.
 
@@ -95,7 +95,7 @@ The Carpentries works to help institutions and individuals spread skills for dat
 >
 > If you are at an in-person training, your instructor will hand out paper copies of a worksheet. If you are at an online training, you can get a [digital copy here]({{ page.root }}/files/handouts/Carpentries_roles_worksheet_v4.pdf).
 >
-> Take a moment to review member community roles on the [Carpentries' community website](http://static.carpentries.org/community/). Working on your own, match up the roles with the descriptions. When you are done, think about the question at the bottom of the worksheet about what roles you might play, and enter your thoughts in the etherpad.
+> Take a moment to review member community roles on the [Carpentries' community website](http://static.carpentries.org/community/). Working on your own, match up the roles with the descriptions. When you are done, think about the question at the bottom of the worksheet about what roles you might play, and enter your thoughts in the Etherpad.
 >
 >> ## Solution  
 >> Instructors: C
@@ -122,7 +122,7 @@ The Carpentries works to help institutions and individuals spread skills for dat
 ## How a Workshop Works
 
 The [**Carpentries Handbook**](https://docs.carpentries.org/) is a community-developed resource that 
-provides tips, checklists, and points of contact for nearly all Carpentries-related activties in one location. 
+provides tips, checklists, and points of contact for nearly all Carpentries-related activities in one location.
 The Carpentries Handbook is the definitive source for policies and information. 
 Here, we will briefly cover workshop types, core curricula, official logos, and workshop websites. 
 
@@ -211,7 +211,7 @@ The workshop will show up on our websites shortly thereafter.
 > This exercise should take about 25 minutes.
 > 
 > Note: Sometimes web browsers will cache the workshop webpage, so when 
-> you make changes in Github, they don't show up on the workshop webpage
+> you make changes in GitHub, they don't show up on the workshop webpage
 > immediately.  Two ways to avoid this are to use a "private" or 
 > "incognito" mode in your web browser or by following these 
 > [instructions to bypass your browser cache](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache).

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -212,7 +212,7 @@ go around the room, asking each person if they have a question + then answer the
 
 * Exercise: Creating a Workshop Website
    * CK: This takes some time, so some people opt to skip this section.  Inevitably, 
-   when working with a group of mixed experience with Github, some will be able 
+   when working with a group of mixed experience with GitHub, some will be able
    to zip through this exercise, where others will struggle.  We **have** gotten 
    positive feedback about this exercise as well, where learners felt like it was 
    a valuable experience. Can be especially valuable for groups that will probably 

--- a/index.md
+++ b/index.md
@@ -41,7 +41,7 @@ will be certified to teach [Software Carpentry]({{ site.swc_site }}), [Data Carp
     (though of course they should know enough about the subjects of one or more of our lessons
     to be able to teach them).
 
-Feedback on these materials is welcome as an [issue][issues] on the Github repository that hosts this site.
+Feedback on these materials is welcome as an [issue][issues] on the GitHub repository that hosts this site.
 
 **These materials are freely available under a [Creative Commons license][license].**
 


### PR DESCRIPTION
GitHub and Etherpad were already the capitalizations used in the majority of cases; this adapts the few deviating cases.