### PR TITLE
Cross-referencing rubric and demo pages

### DIFF
--- a/_extras/demos_rubric.md
+++ b/_extras/demos_rubric.md
@@ -3,7 +3,7 @@ layout: page
 title: "Suggested Rubric for Teaching Demonstrations"
 ---
 
-This rubric is provided as a guide for Trainers evaluating potential new instructors during the teaching demonstration. Deciding whether a particular trainee passes or fails the demonstration is the sole discretion of the
+This rubric is provided as a guide for Trainers evaluating potential new instructors during the teaching demonstration ([Good lessons to use for demo](https://carpentries.github.io/instructor-training/demo_lessons/index.html)). Deciding whether a particular trainee passes or fails the demonstration is the sole discretion of the
 Trainer. As such, deviation from this rubric is encouraged as needed to accurately assess the trainee's preparation and instructional
 skills.
 


### PR DESCRIPTION
Added a link to each page on the other page, just so it's easier to cross-reference in a hurry.