### PR TITLE
Fix demopad link

### DIFF
--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Checkout Procedure"
 calendar: https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com
-demopad: https://pad.carpentries.org/teaching-demos-recovered
+demopad: https://pad.carpentries.org/teaching-demos-new
 discussionpad: http://pad.software-carpentry.org/community-discussions
 ---
 


### PR DESCRIPTION
In the step 3, the link to the Etherpad direct to a non-working pad (not loading). In the chat of that pad is the link to a new, properly working pad. I put the new link to the working etherpad.


