### PR TITLE
update link to new etherpad for teaching demos

### DIFF
--- a/_episodes/20-checkout.md
+++ b/_episodes/20-checkout.md
@@ -123,5 +123,5 @@ Once you have completed all checkout steps, within about 2 weeks you will receiv
 
 [mentoring]: https://docs.carpentries.org/topic_folders/instructor_development/mentoring_groups.html
 [discussion]: http://pad.software-carpentry.org/community-discussions
-[demo]: https://pad.carpentries.org/teaching-demos-recovered
+[demo]: https://pad.carpentries.org/teaching-demos-new
 [demo rubric]: https://carpentries.github.io/instructor-training/17-performance/index.html


### PR DESCRIPTION
updates the link to the demo etherpad in the checkout lesson.

(Note, it was already updated in the more detailed checkout extras page here https://github.com/carpentries/instructor-training/pull/1016)