### PR TITLE
Updating demos pad links

### DIFF
--- a/_episodes/20-checkout.md
+++ b/_episodes/20-checkout.md
@@ -123,5 +123,5 @@ Once you have completed all checkout steps, within about 2 weeks you will receiv
 
 [mentoring]: https://docs.carpentries.org/topic_folders/instructor_development/mentoring_groups.html
 [discussion]: http://pad.software-carpentry.org/community-discussions
-[demo]: https://pad.carpentries.org/teaching-demos-recovered
+[demo]: https://pad.carpentries.org/teaching-demos
 [demo rubric]: https://carpentries.github.io/instructor-training/17-performance/index.html

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Checkout Procedure"
 calendar: https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com
-demopad: https://pad.carpentries.org/teaching-demos-new
+demopad: https://pad.carpentries.org/teaching-demos
 discussionpad: http://pad.software-carpentry.org/community-discussions
 ---
 


### PR DESCRIPTION
Updating links to demos pad in checkout episode and extras document. (I hope that's all of them!)

New pad: https://pad.carpentries.org/teaching-demos