### PR TITLE
Fixed broken link to icebreaker questions.

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -21,7 +21,7 @@ keypoints:
 
 > ## Getting to know each other
 >
-> If the trainer has chosen an [icebreaker question]({{training_site}}/icebreakers/index.html),
+> If the trainer has chosen an [icebreaker question]({{training_site}}/instructor-training/icebreakers/index.html),
 > participate by writing your answers in the course's shared notes.
 {: .challenge}
 


### PR DESCRIPTION
Needs to be:
https://carpentries.github.io/instructor-training/icebreakers/index.html
instead of:
https://carpentries.github.io/icebreakers/index.html

