### PR TITLE
Included Library Carpentry when talking about lesson format

### DIFF
--- a/_episodes/21-carpentries.md
+++ b/_episodes/21-carpentries.md
@@ -264,8 +264,8 @@ and improve the lessons via "bug fixes" as we go along.
 > ## Lesson Incubation
 >
 > Maybe this instructor training has inspired you to go home and write your
-> own fantastic lesson!  If you'd like to model it after the Software and
-> Data Carpentry lesson format, you can find a template and instructions in [the Carpentries lesson example repository]({{ site.example_repo }}).
+> own fantastic lesson!  If you'd like to model it after the Software, Data and
+> Library Carpentry lesson format, you can find a template and instructions in [the Carpentries lesson example repository]({{ site.example_repo }}).
 {: .callout}
 
 > ## Many Ways to Contribute


### PR DESCRIPTION
Included Library Carpentry when talking about Software and Data Carpentry lesson format. An alternative would be to use "The Carpentries' lesson format", to include all current and future lesson organisations. and avoid the need to updating this.