### PR TITLE
Fix link to icebreakers

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -21,7 +21,7 @@ keypoints:
 
 > ## Getting to know each other
 >
-> If the trainer has chosen an [icebreaker question]({{training_site}}/instructor-training/icebreakers/index.html),
+> If the trainer has chosen an [icebreaker question]({{training_site}}/icebreakers/index.html),
 > participate by writing your answers in the course's shared notes.
 {: .challenge}
 
@@ -34,7 +34,7 @@ to conform to our [Code of Conduct]({{ site.coc }}). This Code of Conduct applie
 ## Introductions
 
 > Introductions set the stage for learning.
-> 
+>
 > --- Tracy Teal, Executive Director, The Carpentries
 {: .testimonial}
 


### PR DESCRIPTION
This didn't give the correct link for a local build,
even though it gets magically fixed for github pages.


It gave an extra 'instructor-training' in the path.
