### PR TITLE
update link to icebreakers take 2

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -21,7 +21,7 @@ keypoints:
 
 > ## Getting to know each other
 >
-> If the trainer has chosen an [icebreaker question]({{ page.training_site }}/icebreakers/index.html),
+> If the trainer has chosen an [icebreaker question](https://carpentries.github.io/instructor-training/icebreakers/index.html),
 > participate by writing your answers in the course's shared notes.
 {: .challenge}
 


### PR DESCRIPTION
neither {{training_site}} nor {{ pagepage.training_site}} site seemed to be working, so I've used the full webaddress. https://github.com/carpentries/instructor-training/issues/1051

