### PR TITLE
provide more instructions about for workshop website

### DIFF
--- a/_episodes/21-carpentries.md
+++ b/_episodes/21-carpentries.md
@@ -214,17 +214,31 @@ be sure to read through the [instructor no-show policy](https://github.com/carpe
 
 In order to communicate with learners,
 and to help us keep track of who's taught what and where,
-each workshop's instructors create a one-page website with information about their workshop.
-Once that has been created,
+instructors create a website with information about their workshop.
+
+To ensure unique names for each event,
+we use the `year-month-day-venue` format for the identifier, the slug.
+For instance, for a workshop that starts on Febuary 22nd, 2022
+at the University of Data Skills,
+the slug would be `2022-02-22-data-skills`.
+If you are teaching a centrally-organized workshop,
+please wait for the email from your regional coordinator
+that will tell you the slug to use for your workshop.
+
+Once that your workshop website has been created,
 the host or lead instructor sends its URL to
 the [workshop coordinator](mailto:team@carpentries.org),
 who adds it to our records.
 The workshop will show up on our websites shortly thereafter.
 
-You may also create an etherpad for your own Carpentries-related events. When you point a browser to a url at
-`pad.carpentries.org/name-of-pad` you will either arrive at an existing etherpad by that name or a brand new
-etherpad with basic Carpentries information at the top.  For workshops we use `year-month-day-venue` as the name
-to ensure unique names.
+You may also create an etherpad for your workshop
+(or other Carpentries-related event).
+When you point a browser to a url at
+`https://pad.carpentries.org/workshop-slug`
+(e.g., `https://pad.carpentries.org/2022-02-22-data-skills`
+for the example above)
+you will either arrive at an existing etherpad by that name or a brand new
+etherpad with basic Carpentries information at the top.
 
 > ## Practice With The Carpentries Infrastructure
 >


### PR DESCRIPTION
provide a little more details (and re-organize) section about how to set up and name workshop websites.