### PR TITLE
Fix AMY links to point to amy.carpentries.org.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ repository: <USERNAME>/<PROJECT>
 email: "checkout@carpentries.org"
 
 # Sites.
-amy_site: "https://amy.software-carpentry.org/workshops"
+amy_site: "https://amy.carpentries.org/workshops"
 carpentries_github: "https://github.com/carpentries"
 carpentries_pages: "https://carpentries.github.io"
 carpentries_site: "https://carpentries.org/"

--- a/_episodes/20-checkout.md
+++ b/_episodes/20-checkout.md
@@ -20,7 +20,7 @@ getting involved in the community in other ways.
 ## Application form
 
 Make sure that you have filled out the Carpentries
-[instructor application form](https://amy.software-carpentry.org/forms/request_training/).
+[instructor application form](https://amy.carpentries.org/forms/request_training/).
 We can not track your progress and make you an official instructor without it. If you have already
 filled out this form, you do not need to submit another application.
 

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -43,7 +43,7 @@ and must be requested before the three months are up. To request an extension, p
 
 > ## Submit an application  
 > To help us track your progress through the checkout process and make sure you get the credit you deserve, you will need to submit an application in our database management system (AMY).
-> If you haven't already, please fill out [the online application form](https://amy.software-carpentry.org/forms/request_training/). For group name, please enter the name your instructor provides.
+> If you haven't already, please fill out [the online application form](https://amy.carpentries.org/forms/request_training/). For group name, please enter the name your instructor provides.
 {: .challenge}
 
 ## Part 1: Submit a Small Contribution to One of Our Lessons
@@ -217,7 +217,7 @@ You do not need to be prepared to teach the supplementary modules for your teach
 
 _Please note that you only need to demonstrate your ability to teach one lesson; once certified you can teach any lesson if you have the relevant expertise. 
 You can indicate the lessons you are comfortable teaching when you update 
-[your instructor profile](https://amy.software-carpentry.org/workshops/trainee-dashboard/)._ 
+[your instructor profile](https://amy.carpentries.org/workshops/trainee-dashboard/)._ 
 
 For your demonstration(s), you will screen-share
 and live code as if your computer was plugged into a projector

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -32,7 +32,7 @@ repository: <USERNAME>/<PROJECT>
 email: "team@carpentries.org"
 
 # Sites.
-amy_site: "https://amy.software-carpentry.org/workshops"
+amy_site: "https://amy.carpentries.org/workshops"
 carpentries_github: "https://github.com/carpentries"
 carpentries_pages: "https://carpentries.github.io"
 carpentries_site: "https://carpentries.org/"

--- a/index.md
+++ b/index.md
@@ -44,7 +44,7 @@ Feedback on these materials is welcome as an [issue][issues] on the GitHub repos
 
 **These materials are freely available under a [Creative Commons license][license].**
 
-[application-form]: https://amy.software-carpentry.org/forms/request_training/
+[application-form]: https://amy.carpentries.org/forms/request_training/
 [conduct]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
 [license]: {{ page.root }}/LICENSE.html
 [issues]: {{ site.github.repository_url }}/issues


### PR DESCRIPTION
AMY seems to have moved from https://amy.software-carpentry.org to https://amy.carpentries.org. Fix links accordingly.