### PR TITLE
Reinstate link to training survey

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,7 @@ training_site: "https://carpentries.github.io/instructor-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"
 workshop_site: "https://carpentries.github.io/workshop-template"
 coc: "https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html"
+training_post_survey: "https://www.surveymonkey.com/r/post-instructor-training"
 
 # Surveys.
 instructor_pre_survey: "https://www.surveymonkey.com/r/instructor_training_pre_survey?workshop_id="


### PR DESCRIPTION
This was deleted in a6437abef9b but is needed for the link in
episode 25 (wraping up) to work.
