### PR TITLE
Fixing broken link

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -21,7 +21,7 @@ keypoints:
 
 > ## Getting to know each other
 >
-> If the trainer has chosen an [icebreaker question]({{ page.training_site }}/icebreakers/index.html),
+> If the trainer has chosen an [icebreaker question]({{ site.training_site }}/icebreakers/index.html),
 > participate by writing your answers in the course's shared notes.
 {: .challenge}
 


### PR DESCRIPTION
There is no local variable to the page `training_site` it is set in `_config.yml` and scoped to `site.training_site`. Should fix the link. 