### PR TITLE
Fixed link to python-novice-inflammation episode

### DIFF
--- a/_episodes/12-homework.md
+++ b/_episodes/12-homework.md
@@ -49,7 +49,7 @@ To prepare for tomorrow, please:
         *   [Working with Files and Directories in the Unix Shell](<{{ site.swc_pages }}/shell-novice/03-create/>)
         *   [Tracking Changes in Git](<{{ site.swc_pages }}/git-novice/04-changes/>)
         *   [Selecting Data in SQL](<{{ site.swc_pages }}/sql-novice-survey/01-select/>)
-        *   [Repeating Actions with Loops in Python](<{{ site.swc_pages }}/python-novice-inflammation/03-loop/>)
+        *   [Repeating Actions with Loops in Python](<{{ site.swc_pages }}/python-novice-inflammation/04-loop/>)
         *   [Exploring Data Frames in R](<{{ site.swc_pages }}/r-novice-gapminder/05-data-structures-part2/>)
 
 

--- a/setup.md
+++ b/setup.md
@@ -46,7 +46,7 @@ Please read through *one* of the episodes below carefully, so that you can do so
 * [Working with Files and Directories in the Unix Shell]({{ site.swc_pages }}/shell-novice/03-create/)
 * [Tracking Changes in Git]({{ site.swc_pages }}/git-novice/04-changes/)
 * [Selecting Data in SQL]({{ site.swc_pages }}/sql-novice-survey/01-select/)
-* [Repeating Actions with Loops in Python]({{ site.swc_pages }}/python-novice-inflammation/02-loop/)
+* [Repeating Actions with Loops in Python]({{ site.swc_pages }}/python-novice-inflammation/04-loop/)
 * [Exploring Data Frames in R]({{ site.swc_pages }}/r-novice-gapminder/05-data-structures-part2/)
 
 **Library Carpentry**


### PR DESCRIPTION
Link to episode _Repeating Actions with Loops_ for python-novice-inflammation is broken in [Setup](https://github.com/carpentries/instructor-training/blob/gh-pages/setup.md).
Replace `02-loop`  with `04-loop`


Link to episode  _Repeating Actions with Loops_ for python-novice-inflammation is broken in [homework episode](https://github.com/carpentries/instructor-training/blob/gh-pages/_episodes/12-homework.md).
Replace `03-loop`  with `04-loop`

Related to #1087