### PR TITLE
Switch order of recommended contribution types

### DIFF
--- a/_episodes/20-checkout.md
+++ b/_episodes/20-checkout.md
@@ -29,9 +29,10 @@ filled out this form, you do not need to submit another application.
 As you read in your homework last night, there are three final steps to complete before qualifying as an instructor. The [instructor checkout webpage]({{ page.root }}/checkout/) explains the procedure in detail. Briefly, the three steps are:
 
 1. Make a contribution to a lesson's content, exercises, or instructor notes by doing **one** of the following:
-   1. Submit a change (i.e. pull request) to fix an existing issue. (Example [good first issues](https://github.com/swcarpentry/python-novice-gapminder/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).)
-   2. Proof-read a lesson and add a new issue describing something to be improved.
-   3. Provide substantive feedback on an existing issue or pull request.
+   1. Providing substantive feedback on an existing issue or pull request (preferred).
+   2. Submiting a change (i.e. pull request) to fix an existing issue. (Example [good first issues](https://github.com/swcarpentry/python-novice-gapminder/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).)
+   3. Proof-reading a lesson and adding a new issue describing something to be improved.
+   
 2.  Take part in a [community discussion][discussion] with experienced instructors.
 3.  Prepare to teach a full Carpentries lesson (i.e. the content of one lesson repository). Then perform a 5-minute [live coding demo][demo] for that lesson starting at a point chosen by the session lead.
 


### PR DESCRIPTION
The [checkout page in extras](https://carpentries.github.io/instructor-training/checkout/index.html#lesson-change) lists possibly types of contributions, starting with the type that we are most encouraging from trainees. This modifies the same list in the lesson episode proper to match the order in the extras file.