### PR TITLE
fix link to kirschner paper

### DIFF
--- a/_episodes/05-memory.md
+++ b/_episodes/05-memory.md
@@ -423,7 +423,7 @@ can be gradually removed.
 Anything you can do to a) recognize and b) support learners in working with the
 limitations of short-term memory will improve the effectiveness of your teaching.
 
-[kirschner-paper]: http://www.cogtech.usc.edu/publications/kirschner_Sweller_Clark.pdf
+[kirschner-paper]: https://www.tandfonline.com/doi/pdf/10.1207/s15326985ep4102_1?needAccess=true
 [memory-test]: https://miku.github.io/activememory/
 [wikipedia-cognitive-load]: https://en.wikipedia.org/wiki/Cognitive_load
 [wikipedia-inquiry]: https://en.wikipedia.org/wiki/Inquiry-based_learning

--- a/_episodes/05-memory.md
+++ b/_episodes/05-memory.md
@@ -423,7 +423,7 @@ can be gradually removed.
 Anything you can do to a) recognize and b) support learners in working with the
 limitations of short-term memory will improve the effectiveness of your teaching.
 
-[kirschner-paper]: https://www.tandfonline.com/doi/pdf/10.1207/s15326985ep4102_1?needAccess=true
+[kirschner-paper]: https://www.tandfonline.com/doi/pdf/10.1207/s15326985ep4102_1
 [memory-test]: https://miku.github.io/activememory/
 [wikipedia-cognitive-load]: https://en.wikipedia.org/wiki/Cognitive_load
 [wikipedia-inquiry]: https://en.wikipedia.org/wiki/Inquiry-based_learning


### PR DESCRIPTION
Just a small edit, the link is dead for the Kirschner paper.

Lots of link options [here](https://scholar.google.com/scholar?oi=bibs&hl=en&cluster=11065780712206344145), not sure what is preferred. 


