### PR TITLE
Mention Help Wanted page and Glosario for checkout

### DIFF
--- a/_episodes/20-checkout.md
+++ b/_episodes/20-checkout.md
@@ -15,7 +15,7 @@ During this period after lunch, we'll be talking about some of the nuts and bolt
 of getting involved in The Carpentries.  First, we'll discuss what actions you'll
 need to take after this training to become a fully certified Instructor.  After that,
 we'll address any questions about The Carpentries organization, running workshops, and
-getting involved in the community in other ways. 
+getting involved in the community in other ways.
 
 ## Application form
 
@@ -28,11 +28,11 @@ filled out this form, you do not need to submit another application.
 
 As you read in your homework last night, there are three final steps to complete before qualifying as an Instructor. The [Instructor checkout webpage]({{ page.root }}/checkout/) explains the procedure in detail. Briefly, the three steps are:
 
-1. Make a contribution to a lesson's content, exercises, or instructor notes by doing **one** of the following:
+1. Make a contribution to any [eligible repository]({{ page.root }}/checkout/index.html#eligible-repositories):
    1. Providing substantive feedback on an existing issue or pull request (preferred).
-   2. Submiting a change (i.e. pull request) to fix an existing issue. (Example [good first issues](https://github.com/swcarpentry/python-novice-gapminder/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).)
+   2. Submiting a change (i.e. pull request) to fix an existing issue. Our [Help Wanted page][help-wanted] lists issues for which lesson maintainers need assistance and is a good place to start when looking for ways to contribute.
    3. Proof-reading a lesson and adding a new issue describing something to be improved.
-   
+
 2.  Take part in a [community discussion][discussion] with experienced Instructors.
 3.  Prepare to teach a full Carpentries lesson (i.e. the content of one lesson repository). Then perform a 5-minute [live coding demo][demo] for that lesson starting at a point chosen by the session lead.
 
@@ -40,21 +40,21 @@ All trainees have 3 months (90 days) from the end date of your training to compl
 extensions for up to a year may be requested by emailing [checkout@carpentries.org](mailto: checkout@carpentries.org).
 
 > ## Carpentries Tools: Etherpad
-> 
-> The Etherpad is a widely used tools in Carpentries workshops and many other activities in the community. 
-> There are etherpads about a many topics, like the two linked in the checkout instructions above. 
-> To make them all findable, the Carpentries manage a ["pad of pads"](https://pad.carpentries.org/pad-of-pads). 
+>
+> The Etherpad is a widely used tools in Carpentries workshops and many other activities in the community.
+> There are etherpads about a many topics, like the two linked in the checkout instructions above.
+> To make them all findable, the Carpentries manage a ["pad of pads"](https://pad.carpentries.org/pad-of-pads).
 > This is a great one to bookmark and use as a reference throughout your checkout process and as a newly minted member
-> of The Carpentries community. 
-> 
+> of The Carpentries community.
+>
 {: .callout}
 
 > ## Checking Out Review with Questions and Answers
-> 
+>
 > In small groups, read and discuss one of the three checkout procedures listed above and described in detail at [this page]({{ page.root }}/checkout/).
-> Make notes in the Etherpad and when you're done, report back to the full group about the requirements for that stage of the process. 
+> Make notes in the Etherpad and when you're done, report back to the full group about the requirements for that stage of the process.
 > What questions do you still have about the checkout process?
-> 
+>
 > This exercise should take about 5 minutes.
 {: .challenge}
 
@@ -125,7 +125,7 @@ Once you have completed all checkout steps, within about 2 weeks you will receiv
 > participating in our Carpentries [Mentoring program][mentoring]!
 {: .callout}
 
-
+[help-wanted]: https://carpentries.org/help-wanted-issues/
 [mentoring]: https://docs.carpentries.org/topic_folders/instructor_development/mentoring_groups.html
 [discussion]: http://pad.carpentries.org/community-discussions
 [demo]: https://pad.carpentries.org/teaching-demos

--- a/_episodes/21-carpentries.md
+++ b/_episodes/21-carpentries.md
@@ -272,12 +272,16 @@ Carpentries organization itself aims to be open, collaborative, and
 based on best practices.  We want to draw together the collective expertise of
 our teaching community to create collaborative lessons, share other materials,
 and improve the lessons via "bug fixes" as we go along.
+Our [Help Wanted page][help-wanted] lists issues for which lesson maintainers need assistance
+and is a good place to start when looking for ways to contribute.
 
 > ## Lesson Incubation
 >
 > Maybe this instructor training has inspired you to go home and write your
 > own fantastic lesson!  If you'd like to model it after the Software, Data and
-> Library Carpentry lesson format, you can find a template and instructions in [The Carpentries lesson example repository]({{ site.example_repo }}).
+> Library Carpentry lesson format, you can find a template and instructions in
+> [The Carpentries lesson example repository]({{ site.example_repo }}),
+> and a place to develop it in [The Carpentries Incubator][carpentries-incubator].
 {: .callout}
 
 > ## Many Ways to Contribute
@@ -331,3 +335,6 @@ build local and global communities of practice around  skills for data analysis,
 >
 > Take a couple of minutes to sign up for The Carpentry discussion channels you want to stay involved with.
 {: .challenge}
+
+[help-wanted]: https://carpentries.org/help-wanted-issues/
+[carpentries-incubator]: https://github.com/carpentries-incubator/proposals/

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -53,7 +53,8 @@ Our lessons are maintained and improved by the people who teach them,
 so this part of the checkout procedure gives you a chance to familiarize yourself
 with our collaborative curriculum development process.
 
-Trainees must make a contribution to a lesson's content, exercises, or instructor's guide by doing one of the following:
+If contributing to a lesson,
+trainees must make a contribution to the lesson's content, exercises, or instructor's guide by doing one of the following:
 
 1. Providing substantive feedback on an existing issue or pull request (preferred).
 2. Submitting a change to fix an existing issue. Our [Help Wanted page][help-wanted] lists issues for which lesson maintainers need assistance and is a good place to start when looking for ways to contribute.

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -12,7 +12,7 @@ After you have completed the two-day instructor training workshop,
 you must go through these three steps to complete your training and be
 fully certified as a Carpentries instructor:
 
-1.  Make (and [send us a link to](mailto:{{ site.email }})) a [contribution to a lesson's content, exercises, or instructor's guide](#lesson-change).
+1.  Make (and [send us a link to](mailto:{{ site.email }})) a [contribution to a lesson or glossary](#lesson-change).
 2.  Take part in an online [community discussion session](#discussion-session).
 3.  Teach a short [demonstration lesson](#demo-lesson) online.
 
@@ -23,9 +23,9 @@ two weeks after completing all the requirements.
 These checkout steps aim to introduce you to key components of being a Carpentries instructor that are difficult to fully cover in the classroom
 setting of the two-day training.  These are:
 
-1.  Contributing to our lesson materials.  As our materials are developed by the
+1.  Contributing to our materials.  As our materials are developed by the
     community, we want to ensure that all instructors know where and how to contribute
-    to our materials, particularly so that you can contribute in the future.
+    to them, particularly so that you can contribute in the future.
 
 2.  Participating in the larger Carpentry instructor community.  We
     include the community discussion session in the checkout because we hear
@@ -78,9 +78,9 @@ to that lesson. You can access a lesson's GitHub repository by clicking on the G
 
 Please follow the guidelines in the appropriate CONTRIBUTING.md file when making lesson contributions.
 
-If contributing to Glosario, trainees can make a change in the form of
-introducing a relevant new term to the glossary or
-adding a definition to an existing term in another language.
+If contributing to Glosario,
+trainees must introduce a relevant new term to the glossary or
+add a definition to an existing term in another language.
 
 Please note that:
 

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -59,6 +59,10 @@ Trainees must make a contribution to a lesson's content, exercises, or instructo
 2. Submitting a change to fix an existing issue. Our [Help Wanted page][help-wanted] lists issues for which lesson maintainers need assistance and is a good place to start when looking for ways to contribute.
 3. Proof-reading a lesson and adding a new issue describing something to be improved.
 
+If contributing to Glosario, trainees can make a change in the form of
+introducing a relevant new term to the glossary or
+adding a definition to an existing term in another language.
+
 <a name="eligible-repositories"></a>A contribution will be valid for checkout if it is made to:
 
 * any [Software Carpentry]({{ site.swc_site }}/lessons/), [Data Carpentry]({{ site.dc_site }}/lessons/), or [Library Carpentry]({{ site.lc_site }}/lessons/) lesson

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -17,15 +17,15 @@ fully certified as a Carpentries instructor:
 3.  Teach a short [demonstration lesson](#demo-lesson) online.
 
 Tasks are listed in the order most of our instructor trainees complete the checkout process, but
-you can complete them in any order. Trainees will receive a certificate of completion approximately 
-two weeks after completing all the requirements. 
+you can complete them in any order. Trainees will receive a certificate of completion approximately
+two weeks after completing all the requirements.
 
 These checkout steps aim to introduce you to key components of being a Carpentries instructor that are difficult to fully cover in the classroom
 setting of the two-day training.  These are:
 
 1.  Contributing to our lesson materials.  As our materials are developed by the
     community, we want to ensure that all instructors know where and how to contribute
-    to our materials, particularly so that you can contribute in the future. 
+    to our materials, particularly so that you can contribute in the future.
 
 2.  Participating in the larger Carpentry instructor community.  We
     include the community discussion session in the checkout because we hear
@@ -41,12 +41,12 @@ Trainees will have three months to complete the checkout exercises. Extensions m
 and must be requested before the three months are up. To request an extension, please [contact us](mailto:{{ site.email }}).
 
 
-> ## Submit an application  
+> ## Submit an application
 > To help us track your progress through the checkout process and make sure you get the credit you deserve, you will need to submit an application in our database management system (AMY).
 > If you haven't already, please fill out [the online application form](https://amy.carpentries.org/forms/request_training/). For group name, please enter the name your instructor provides.
 {: .challenge}
 
-## Part 1: Submit a Small Contribution to One of Our Lessons
+## Part 1: Submit a Small Contribution to a Lesson or Glossary
 <a name="lesson-change"></a>
 
 Our lessons are maintained and improved by the people who teach them,
@@ -56,17 +56,24 @@ with our collaborative curriculum development process.
 Trainees must make a contribution to a lesson's content, exercises, or instructor's guide by doing one of the following:
 
 1. Providing substantive feedback on an existing issue or pull request (preferred).
-2. Submitting a change to fix an existing issue.(Example [good first issues](https://github.com/swcarpentry/python-novice-gapminder/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).)
+2. Submitting a change to fix an existing issue. Our [Help Wanted page][help-wanted] lists issues for which lesson maintainers need assistance and is a good place to start when looking for ways to contribute.
 3. Proof-reading a lesson and adding a new issue describing something to be improved.
 
-Contributions to Data Carpentry and Library Carpentry materials may be submitted through GitHub or by [email](mailto:{{ site.email }}). Contributions to Software Carpentry materials must be submitted through GitHub.
+<a name="eligible-repositories"></a>A contribution will be valid for checkout if it is made to:
+
+* any [Software Carpentry]({{ site.swc_site }}/lessons/), [Data Carpentry]({{ site.dc_site }}/lessons/), or [Library Carpentry]({{ site.lc_site }}/lessons/) lesson
+* any [community developed lesson](https://carpentries.org/community-lessons/)
+* our open source, multilingual glossary of data science terms, [Glosario](glosario-github)
+
+Contributions to Data Carpentry and Library Carpentry materials may be submitted through GitHub or by [email](mailto:{{ site.email }}). Contributions to Software Carpentry materials, community developed lessons, and Glosario must be submitted through GitHub.
 
 Each lesson has a CONTRIBUTING.md file in its repository on GitHub. This file explains best practices for contributing
-to that lesson. You can access a lesson's GitHub repository by clicking on the GitHub kitty icon in the "Repository" column for that lesson on the lesson page. The lesson pages can be found at:  
+to that lesson. You can access a lesson's GitHub repository by clicking on the GitHub kitty icon in the "Repository" column for that lesson on the lesson page. The lesson pages can be found at:
 
-* [https://datacarpentry.org/lessons/]({{ site.dc_site }}/lessons/)
-* [https://software-carpentry.org/lessons/]({{ site.swc_site }}/lessons/)
-* [https://librarycarpentry.org/lessons/]({{ site.lc_site }}/lessons/) 
+* [{{ site.dc_site }}/lessons/]({{ site.dc_site }}/lessons/)
+* [{{ site.swc_site }}/lessons/]({{ site.swc_site }}/lessons/)
+* [{{ site.lc_site }}/lessons/]({{ site.lc_site }}/lessons/)
+* [https://carpentries.org/community-lessons/](https://carpentries.org/community-lessons/)
 
 Please follow the guidelines in the appropriate CONTRIBUTING.md file when making lesson contributions.
 
@@ -115,7 +122,7 @@ Please note that:
     we would like our current learning objectives to be checked against the actual lesson content,
     and to be framed in terms of observables
     (e.g., "Learner will be able to do X") rather than intangibles (e.g., "Learner will appreciate X").
-    
+
 For more details on the workflow of how to contribute via GitHub, see this
 community [contributed guide](https://github.com/dmgt/swc_github_flow/blob/master/for_novice_contributors.md)
 
@@ -194,7 +201,7 @@ The final step is to sign up for a 5-minute demonstration online using
 [the teaching demo schedule Etherpad]({{page.demopad}})
 (or add yourself to the top of the pad if none of the available times work for you).
 
-The link to connect to the video conference is at the top of the Etherpad. 
+The link to connect to the video conference is at the top of the Etherpad.
 Please be sure to use a headset with a built-in microphone during the session
 rather than open-air speakers and your laptop's built-in microphone,
 since the latter often lead to audio quality problems.
@@ -207,19 +214,19 @@ We may not be able to accommodate all languages.
 
 For your teaching demonstration, you will prepare to teach a lesson from one of the
 Carpentries lesson programs. You can refer to the lists of [Software Carpentry lessons](https://software-carpentry.org/lessons/), [Data Carpentry lessons](http://www.datacarpentry.org/lessons/), and [Library Carpentry lessons](https://librarycarpentry.org/lessons/) on the websites.
-A lesson corresponds to a single line in the lesson table and a single repository in GitHub. 
-(An example of a lesson: [R for Reproducible Scientific Analysis](http://swcarpentry.github.io/r-novice-gapminder/)). 
+A lesson corresponds to a single line in the lesson table and a single repository in GitHub.
+(An example of a lesson: [R for Reproducible Scientific Analysis](http://swcarpentry.github.io/r-novice-gapminder/)).
 Some lessons have supplementary modules.
-You do not need to be prepared to teach the supplementary modules for your teaching demonstration.  
+You do not need to be prepared to teach the supplementary modules for your teaching demonstration.
 
-You will be asked to teach a short segment from your chosen lesson from this 
-[list of suggested episodes](https://carpentries.github.io/instructor-training/demo_lessons/index.html). 
-The host of the session will pick a segment of the lesson for you to teach on the day of the 
+You will be asked to teach a short segment from your chosen lesson from this
+[list of suggested episodes](https://carpentries.github.io/instructor-training/demo_lessons/index.html).
+The host of the session will pick a segment of the lesson for you to teach on the day of the
 demonstration (An example for a segment could be: [Data Structures](http://swcarpentry.github.io/r-novice-gapminder/04-data-structures-part1/index.html)), so you must be prepared to teach any part of your chosen lesson.
 
-_Please note that you only need to demonstrate your ability to teach one lesson; once certified you can teach any lesson if you have the relevant expertise. 
-You can indicate the lessons you are comfortable teaching when you update 
-[your instructor profile](https://amy.carpentries.org/workshops/trainee-dashboard/)._ 
+_Please note that you only need to demonstrate your ability to teach one lesson; once certified you can teach any lesson if you have the relevant expertise.
+You can indicate the lessons you are comfortable teaching when you update
+[your instructor profile](https://amy.carpentries.org/workshops/trainee-dashboard/)._
 
 For your demonstration(s), you will screen-share
 and live code as if your computer was plugged into a projector
@@ -241,9 +248,11 @@ we will send you your certificate
 and instructions on how to add yourself to the teaching roster and our website.
 If for any reason the trainer leading the session feels that you should try again,
 you will be told what to focus on
-and when and where to sign up for another session. Here is a [rubric](https://carpentries.github.io/instructor-training/demos_rubric/) made available to Trainers to aid with scoring. 
+and when and where to sign up for another session. Here is a [rubric](https://carpentries.github.io/instructor-training/demos_rubric/) made available to Trainers to aid with scoring.
 
 ## Contacting Us
 
 If you have any questions or suggestions about any of the above,
 please [contact us](mailto:{{ site.email }}).
+
+[glosario-github]: https://github.com/carpentries/glosario/

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -53,22 +53,18 @@ Our lessons are maintained and improved by the people who teach them,
 so this part of the checkout procedure gives you a chance to familiarize yourself
 with our collaborative curriculum development process.
 
+<a name="eligible-repositories"></a>A contribution will be valid for checkout if it is made to:
+
+* any [Software Carpentry]({{ site.swc_site }}/lessons/), [Data Carpentry]({{ site.dc_site }}/lessons/), or [Library Carpentry]({{ site.lc_site }}/lessons/) lesson
+* any [community developed lesson](https://carpentries.org/community-lessons/)
+* our open source, multilingual glossary of data science terms, [Glosario](glosario-github)
+
 If contributing to a lesson,
 trainees must make a contribution to the lesson's content, exercises, or instructor's guide by doing one of the following:
 
 1. Providing substantive feedback on an existing issue or pull request (preferred).
 2. Submitting a change to fix an existing issue. Our [Help Wanted page][help-wanted] lists issues for which lesson maintainers need assistance and is a good place to start when looking for ways to contribute.
 3. Proof-reading a lesson and adding a new issue describing something to be improved.
-
-If contributing to Glosario, trainees can make a change in the form of
-introducing a relevant new term to the glossary or
-adding a definition to an existing term in another language.
-
-<a name="eligible-repositories"></a>A contribution will be valid for checkout if it is made to:
-
-* any [Software Carpentry]({{ site.swc_site }}/lessons/), [Data Carpentry]({{ site.dc_site }}/lessons/), or [Library Carpentry]({{ site.lc_site }}/lessons/) lesson
-* any [community developed lesson](https://carpentries.org/community-lessons/)
-* our open source, multilingual glossary of data science terms, [Glosario](glosario-github)
 
 Contributions to Data Carpentry and Library Carpentry materials may be submitted through GitHub or by [email](mailto:{{ site.email }}). Contributions to Software Carpentry materials, community developed lessons, and Glosario must be submitted through GitHub.
 
@@ -81,6 +77,10 @@ to that lesson. You can access a lesson's GitHub repository by clicking on the G
 * [https://carpentries.org/community-lessons/](https://carpentries.org/community-lessons/)
 
 Please follow the guidelines in the appropriate CONTRIBUTING.md file when making lesson contributions.
+
+If contributing to Glosario, trainees can make a change in the form of
+introducing a relevant new term to the glossary or
+adding a definition to an existing term in another language.
 
 Please note that:
 

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -261,3 +261,4 @@ If you have any questions or suggestions about any of the above,
 please [contact us](mailto:{{ site.email }}).
 
 [glosario-github]: https://github.com/carpentries/glosario/
+[help-wanted]: https://carpentries.org/help-wanted-issues/


### PR DESCRIPTION
1. include Incubator lessons and Glosario in list of repositories valid for checkout
2. direct trainees to Help Wanted page to find a way to contribute
3. create a list of eligible repositories for the contribution step of checkout, link to this from body of lesson - a single point of reference should make it easier to maintain this list.