### PR TITLE
fix urls by removing static prefix

### DIFF
--- a/_episodes/21-carpentries.md
+++ b/_episodes/21-carpentries.md
@@ -306,13 +306,13 @@ As you can imagine, based on the above, there are many aspects of running The Ca
 While there are a small number of dedicated Core Team members who work for The Carpentries organization,
 the real power of The Carpentries is in its community of volunteers that take on all sorts of
 roles to teach and organize workshops, help produce and maintain lessons, and most importantly,
-build local and global communities of practice around  skills for data analysis, computational thinking, and research software development. Our community depends on individuals like you who are passionate about expanding these communities of practice through inclusive and evidence-based instructional practices, and can contribute your perspective and expertise to continually refine our instructional materials and practices.  A full description of the breadth and diversity of community member roles, an overview of The Carpentries various social media channels, a calendar of future community events, and descriptions of mailing lists used by the community can be found [here on The Carpentries website](http://static.carpentries.org/community/) and also on the [getting connected page](https://carpentries.org/connect/).
+build local and global communities of practice around  skills for data analysis, computational thinking, and research software development. Our community depends on individuals like you who are passionate about expanding these communities of practice through inclusive and evidence-based instructional practices, and can contribute your perspective and expertise to continually refine our instructional materials and practices.  A full description of the breadth and diversity of community member roles, an overview of The Carpentries various social media channels, a calendar of future community events, and descriptions of mailing lists used by the community can be found [here on The Carpentries website](http://carpentries.org/community/) and also on the [getting connected page](https://carpentries.org/connect/).
 
 > ## Participating in The Carpentries -- What's Your Role?
 >
 > If you are at an in-person training, your Trainer will hand out paper copies of a worksheet. If you are at an online training, you can get a [digital copy here]({{ page.root }}/files/handouts/Carpentries_roles_worksheet_v4.pdf).
 >
-> Take a moment to review member community roles on [The Carpentries community website](http://static.carpentries.org/community/). Working on your own, match up the roles with the descriptions. When you are done, think about the question at the bottom of the worksheet about what roles you might play, and enter your thoughts in the Etherpad.
+> Take a moment to review member community roles on [The Carpentries community website](http://carpentries.org/community/). Working on your own, match up the roles with the descriptions. When you are done, think about the question at the bottom of the worksheet about what roles you might play, and enter your thoughts in the Etherpad.
 >
 >> ## Solution
 >> Instructors: C


### PR DESCRIPTION
I think this is the last page that still had broken links due to the carpentries url changing to no longer have "static"
