### PR TITLE
Add alt text for all images

### DIFF
--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -52,7 +52,8 @@ in her studies of
 through practice and formal instruction, learners acquire skills and advance through distinct stages. In simplified form,
 the three stages of this model are:
 
-![Novice, Competent Practitioner, Expert](../fig/skill-level.svg)
+![Three people, labeled from left to right as "Novice", "Competent Practitioner", and "Expert". Underneath the people,
+an arrow labelled "Experience level" points from left to right. Underneath the figure labelled "Novice" a quote says "I'm not sure what questions to ask." The Competent Practitioner says "I'm pretty confident, but I still look stuff up a lot!" The Expert says "I've been doing this on a daily basis for years!"](../fig/skill-level.svg)
 
 *   *Novice*: someone who doesn't know what they don't know, i.e.,
     they don't yet know what the key ideas in the domain are or how they relate.
@@ -102,7 +103,7 @@ does not have to be completely accurate in order to be useful:
 for example, the average driver's mental model of how a car works probably doesn't include
 most of the complexities that a mechanical engineer would be concerned with.
 
-![Mental Models](../fig/mental_models.svg)
+![Three collections of six circles. The first collection is labelled "Novice" and has only two arrows connecting some of the circles. The second collection, labelled "Competent Practitioner" has six connecting arrows. The third collection, labelled "Expert", is densly connected, with eight connecting arrows.](../fig/mental_models.svg)
 
 We will discuss the mental models of experts in more detail in [a later lesson]({{ page.root }}/03-expertise/).
 

--- a/_episodes/05-memory.md
+++ b/_episodes/05-memory.md
@@ -146,20 +146,20 @@ for ch in "abc":
 
 The three key concepts used in this loop are:
 
-![Key Concepts](../fig/for-loop-concepts.png)
+![Three rectangles labelled "loop variable", "collection", and "loop body".](../fig/for-loop-concepts.png)
 
 The key relationships,
 which are as important as the concepts themselves,
 are:
 
-![Relationships](../fig/for-loop-arcs.png)
+!["Loop variable" is connected to "collection" with an arrow labelled "takes each value in order" and to "loop body" with an arrow labelled "changes each time". "Loop body" is connected to "collection" by an arrow reading "runs for each".](../fig/for-loop-arcs.png)
 
 A quick count shows that there are actually 6 things here,
 not just 3,
 so we're already brushing up against the limits of short-term memory.
 If we add two more facts to show things that are usually (but not always) true:
 
-![Recommendations](../fig/for-loop-rec.png)
+![Two arrows are added to the previous figure, showing that the loop variable and collection are usually not changed by the loop body.](../fig/for-loop-rec.png)
 
 the count rises to 8,
 which is a good size for a single teaching episode.

--- a/_episodes/11-practice-teaching.md
+++ b/_episodes/11-practice-teaching.md
@@ -150,7 +150,7 @@ Now that you've had some practice observing teaching and giving feedback, let's 
 
 Sometimes it can be hard to receive feedback, especially negative feedback.
 
-![Feedback Feelings](../fig/deathbulge-jerk.jpg "Comic from http://www.deathbulge.com/comics/155")
+![A three panel comic. In the first panel, a smiling figure is surrounded by speech bubbles with mostly positive feedback. In the second panel, the figure is eating dinner. All of the previous speech bubbles appear faded out, except the one negative bubble. The third panel shows the figure in bed, with an unhappy face, with the one piece of negative feedback lingering after all others have faded.](../fig/deathbulge-jerk.jpg "Comic from http://www.deathbulge.com/comics/155")
 
 Feedback is most effective when the people involved
 share ground rules and expectations. In Carpentries teaching, we use the 2x2
@@ -167,7 +167,7 @@ in a way that facilitates growth.
 *   Initiate feedback as the instructor. It's better to ask for feedback than to receive it unwillingly.
 
 *   Ask for and give specific feedback. See a great example of this from
-  this Lunar Baboon comic: ![Giving Good Feedback](../fig/feedback-artwork.jpg "Comic from http://www.lunarbaboon.com/comics/feedback.html")
+  this Lunar Baboon comic: ![A four panel comic. The first panel shows a kid saying, "Dad, that kid said my artwork sucked." In the second panel, the father rolls up his sleeves and says "Oh yeah, well I'm going to teach him a lesson!" In the third panel, the child watches while the father points to a whiteboard on which is written "How to Give Good Feedback: 1) Be positive, 2) Be specific, 3) Give a next step." The fourth panel shows the child saying "Good use of color, but I think it needs more detail." The artist responds "I'll definitely consider that, thanks."](../fig/feedback-artwork.jpg "Comic from http://www.lunarbaboon.com/comics/feedback.html")
 
   As an instructor one way to get specific feedback is to provide questions that
   focus the responses.  Writing your own feedback questions allows you to frame

--- a/_episodes/15-lesson-study.md
+++ b/_episodes/15-lesson-study.md
@@ -107,7 +107,7 @@ the bottom. In the long term, everybody wants to be at the top. However, in aimi
 need to be mindful about helping them to ["grow a level,"](https://software-carpentry.org/blog/2018/03/tractenberg-summary.html) helping them to recognize when they have achieved that growth, and
 guiding them to look ahead to where we might not be able to take them.
 
-![Bloom's Taxonomy](../fig/Blooms.png)
+![A six level pyramid labelled from bottom to top: remember, understand, apply, analyze, evaluate, create. Next to each level is a description of that stage and a list of action verbs associated with each level. From the bottom - Remember is recall facts and basic concepts: define, duplicate, list, memorize, repeat, state. Understand is explain ideas or concepts: classify, describe, discuss, explain, identify, locate, recognize, report, select, translate. Apply is use information in new situations: execute, implement, solve, use, demonstrate, interpret, operate, schedule, sketch. Analyze is draw connections among ideas: differentiate, organize, relate, compare, contrast, distinguish, examine, experiment, question, test. Evaluate is justify a stand or decision: appraise, argue, defend, judge, select, support, value, critique, weight. Create is produce new or original work: design, assemble, construct, conjecture, develop, formulate, author, investigate.](../fig/Blooms.png)
 
 Image credit: Vanderbilt University Center for Teaching
 

--- a/_episodes/21-carpentries.md
+++ b/_episodes/21-carpentries.md
@@ -47,7 +47,7 @@ Maintainers, helpers, and supporters from
 [Software Carpentry]({{ site.swc_site }}), [Data Carpentry]({{ site.dc_site }}) and [Library Carpentry]({{ site.lc_site }})
 who share a mission to teach foundational computational and data science skills.
 
-![A brief history](../fig/SWCDChistory.png)
+![A very brief history of The Carpentries. A timeline - 1998 Software Carpentry is founded by Greg Wilson and Bret Gorda to teach researchers better software development skills. 2005 lesson materials are made open source with support from the Python Software Foundation. 2012 Software Carpentry workshop efforts scale with support from the Alfred P. Sloan Foundation and the Mozila Science Lab. 2013 the first Software Carpentry for Librarians workshops are organized in the US and Canada. 2014 Data Carpentry is founded by Karen Cranston, Hilmar Lapp, Tracy Teal, and Ethan White with support from the National Science Foundation. James Baker receives support from the Software Sustainability Institute to develop and implement Library Carpentry. Software Carpentry Foundation is founded under the auspices of NumFOCUS. 2015 - Data Carpentry workshop efforts scaled with support from the Gordon and Betty Moore Foundation. 2018 in January, Software Carpentry and Data Carpentry merge to form The Carpentries, a fiscally sponsored project of Community Initiatives. In November, Library Carpentry joins as a Lesson Program.](../fig/SWCDChistory.png)
 
 You can learn more about the history and goals of each Lesson Program by reading
 "[Software Carpentry: Lessons Learned](https://f1000research.com/articles/3-62/v2)",
@@ -91,7 +91,7 @@ computational challenges,
 
 In a visual representation, these similarities and differences look like this:
 
-![The Carpentries Similarities and Differences](../fig/carpentries-venn-diagram_20200904.svg)
+![Three intersecting circles labelled Software Carpentry, Data Carpentry, and Library Carpentry. Software and Data Carpentry both focus on research focused computational skills. Data and Library Carpentry are both domain targeted. Software and Library Carpentry both have modular a curriculum. All three Lesson Programs provide novice-level training, two-day workshops to address gaps in computational skills, taught by volunteer instructors applying Carpentries teaching practices.](../fig/carpentries-venn-diagram_20200904.svg)
 
 
 ## What is a Carpentries Workshop? The Rules.


### PR DESCRIPTION
This PR is my attempt to add alternative text to all images in the lesson. I've tried to follow the guidelines in [this guide from Harvard's digital accessibility office](https://accessibility.huit.harvard.edu/describe-content-images). I am by no means claiming these are the perfect alt texts to have for each of these images, and welcome additions/clarifications/changes. In particular, the two images in 21-carpentries.md (a timeline and a Venn diagram) were challenging, as was the Bloom's taxonomy diagram. We should probably have that information summarized in text form in the lesson body, not just in alt text. I hope however that these additions get us a step closer towards making our lessons accessible to the Blind and visually impaired. 