### PR TITLE
Focus learning objective study on single episode

### DIFF
--- a/_episodes/15-lesson-study.md
+++ b/_episodes/15-lesson-study.md
@@ -113,8 +113,7 @@ Image credit: Vanderbilt University Center for Teaching
 
 > ## Evaluate Learning Objectives
 >
-> Your instructor has posted links to a handful of current Carpentries lessons in the Etherpad.
-> Select one learning objective from one of those lessons,
+> Select one learning objective from the episode you've used for teaching practice,
 > then complete the following steps to evaluate it.
 >
 > 1. Identify the learning objective verb. How specifically does this verb describe the desired learner outcome?
@@ -136,7 +135,7 @@ Awareness of the learning process, also known as "metacognition," will also help
 
 > ## Where are your checkpoints?
 >
-> Have a look at your lesson again. Choose a learning objective, and identify
+> Have a look at your learning objective again and identify
 > *where* in the lesson that objective should reasonably be achieved. How will
 > you know that that objective has been met for all learners? Will this be clear
 > to them?


### PR DESCRIPTION
 taught last week with having trainees focus more on the episode they're teaching from.  I think it worked well. In particular I didn't have trainees complain that this exercise was too hard or not enough time was allocated, and I didn't extend the time. Their analyses were more reflective and their follow up questions lead to deeper discussion and questions about formative assessment again, instead of getting stuck on blooms only. 

I think when we leave it open for them to choose, trainees spend a long time looking at different lessons and episodes within them to choose a learning objective.  By directing them to continue where they are, they can focus on the learning objective and applying Blooms. 

