### PR TITLE
Update links to HTTPS

### DIFF
--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -3,7 +3,7 @@ layout: page
 title: "Checkout Procedure"
 calendar: https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com
 demopad: https://pad.carpentries.org/teaching-demos
-discussionpad: http://pad.software-carpentry.org/community-discussions
+discussionpad: https://pad.carpentries.org/community-discussions
 discussioninfo: https://docs.carpentries.org/topic_folders/instructor_development/community_discussions.html
 ---
 
@@ -233,14 +233,14 @@ We may not be able to accommodate all languages.
 For your teaching demonstration, you will prepare to teach a lesson from one of the
 Carpentries lesson programs. You can refer to the lists of [Software Carpentry lessons](https://software-carpentry.org/lessons/), [Data Carpentry lessons](http://www.datacarpentry.org/lessons/), and [Library Carpentry lessons](https://librarycarpentry.org/lessons/) on the websites.
 A lesson corresponds to a single line in the lesson table and a single repository in GitHub.
-(An example of a lesson: [R for Reproducible Scientific Analysis](http://swcarpentry.github.io/r-novice-gapminder/)).
+(An example of a lesson: [R for Reproducible Scientific Analysis](https://swcarpentry.github.io/r-novice-gapminder/)).
 Some lessons have supplementary modules.
 You do not need to be prepared to teach the supplementary modules for your teaching demonstration.
 
 You will be asked to teach a short segment from your chosen lesson from this
 [list of suggested episodes](https://carpentries.github.io/instructor-training/demo_lessons/index.html).
 The host of the session will pick a segment of the lesson for you to teach on the day of the
-demonstration (An example for a segment could be: [Data Structures](http://swcarpentry.github.io/r-novice-gapminder/04-data-structures-part1/index.html)), so you must be prepared to teach any part of your chosen lesson.
+demonstration (An example for a segment could be: [Data Structures](https://swcarpentry.github.io/r-novice-gapminder/04-data-structures-part1/index.html)), so you must be prepared to teach any part of your chosen lesson.
 
 _Please note that you only need to demonstrate your ability to teach one lesson; once certified you can teach any lesson if you have the relevant expertise.
 You can indicate the lessons you are comfortable teaching when you update


### PR DESCRIPTION
This is mostly important for the link to the community discussion pad, which currently links to a page that doesn't support HTTPS (before redirecting to another domain that supports HTTPS). Therefore, this causes issues in browsers that are configured for HTTPS-only navigation.
