### PR TITLE
Language Tone and Evidence for Claims in Part 03 — Expertise

### DIFF
--- a/_episodes/03-expertise.md
+++ b/_episodes/03-expertise.md
@@ -253,9 +253,9 @@ They may not care how hash tables work,
 or even that hash tables exist; they just want to know how to process data faster.
 We therefore have to make sure that everything we teach is useful right away,
 and conversely that we do not teach anything just because it is "fundamental".
-- Believing that something will be hard to learn is a self-fulfilling prophecy. Researchers already believe that computing is hard, a belief that is exacerbated by "experts" telling them that things should be easy when, in the researcher's experience, they are not.  Paradoxically, this is why it’s important not to say that something is easy.  If someone who has been told that tries it, and it doesn’t work, they are more likely to become discouraged.
+- Believing that something will be hard to learn is a self-fulfilling prophecy. Some researchers already believe that computing is hard, a belief that would be exacerbated by "experts" telling them that things should be easy when, in the researcher's experience, they are not.  Paradoxically, this is why it’s important not to say that something is easy.  If someone who has been told that a particular task is easy, and then their solution doesn't work, they are more likely to become discouraged.
 
-It is also why installing and configuring software is
+It is also why any difficulties with installing and configuring software is
 a much bigger problem for us than experienced programmers like to acknowledge.
 It is not just the time we lose at the start of workshops
 as we try to get a Unix shell working on Windows,

--- a/_episodes/03-expertise.md
+++ b/_episodes/03-expertise.md
@@ -138,14 +138,8 @@ seem trivial to you, as they often will.
 {: .challenge}
 
 Another potential challenge for experts who teach is known in the literature as *expert blind spot*.
-Experts are frequently so familiar with their subject
-that they can no longer imagine what it is like to *not* understand the world that way - this
-inability to consider the material from a non-expert perspective can lead to what is
-known as the *expertise-reversal effect* - experts are often
-less good at teaching a subject to novices than people with less expertise
-who still remember what it is like to have to learn the things.
-This effect can be overcome with training,
-but it is part of the reason world-famous researchers are often poor lecturers.
+Experts are frequently so familiar with their subject that they can no longer imagine what it is like to *not* understand the world that way.
+Sometimes, experts may omit the instructional guidance that is necessary for novices because such additional guidance may not be suited to advanced learners. This relative effectiveness of different learning support is known as the *expertise-reversal effect*. Experts can ensure optimal learning outcomes by receiving training in the level of instructional guidance is appropriate to the target learners.
 
 > ## Expert Awareness Gap
 >  


### PR DESCRIPTION
This pull request addresses two core issues in the 3rd component (Expertise).

**1) Less stereotypical language of researchers**
The language used to describe researchers inadvertently was quite stereotypical in tone, and made generalisations about a broader group in a tone that did not conform well with the community standards. The minor edits (5e5c21a) address this issue, and also fix a minor grammatical issue around installation.

**2)  Improve section on the expertise-reversal effect**

The existing discussion of the expertise-reversal effect was inaccurate. The effect does not suggest that experts are "less good" at teaching than novices. What it suggests is that the relative amount of instructional support and guidance has differential impact depending on the level of expertise in a topic area. It implies that for experts, walking through all the details of concepts actually can have a negative impact on performance; while for novices, the absence of these materials can have a negative impact.

For example:
"The expertise reversal is a reversal in the relative effectiveness of instructional methods as levels of learner knowledge in a domain change." - https://link.springer.com/article/10.1007/s11251-009-9102-0

https://impact.chartered.college/article/expertise-reversal-effect-instructional-implications/

I've tried to remain faithful to the original points raised, but be more faithful to the scientific body of work underpinning the effect. I have also removed the point that "experts" are poor lecturers, which there is little evidence of, and I do not think supports learners in this environment (and may in fact raise the exact issues with instructors that this article is trying to address).

------

I have not recompiled the repository, however. Any comments on this submission are very much appreciated.