### PR TITLE
Retitles references page

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -1,5 +1,6 @@
 ---
 layout: reference
+title: "Key Points and References"
 root: .
 ---
 


### PR DESCRIPTION
I'm unfamiliar with the page:reference in the yaml header so I don't know for sure that this will work, but it seems like a legitimate way to change the title of the References page to something other than "Books"?