### PR TITLE
Add Dunning link

### DIFF
--- a/_episodes/18-preparation.md
+++ b/_episodes/18-preparation.md
@@ -233,4 +233,5 @@ we will talk about how to prepare with your team to create a cohesive classroom 
 
 [Wiggins]: https://www.worldcat.org/title/understanding-by-design/oclc/56491025
 [Config]: https://github.com/carpentries/workshop-template/wiki/Configuration-Problems-and-Solutions
+[Dunning]: https://en.wikipedia.org/wiki/Dunning%E2%80%93Kruger_effect
 


### PR DESCRIPTION
Added link for Dunning-Kruger effect (from raw file of Episode 2: https://github.com/carpentries/instructor-training/blob/d3100fc08a689fcbbda48622f008eb31d1cc1652/_episodes/02-practice-learning.md), so link is clickable and text is formatted correctly.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
