### PR TITLE
fix typo in EIA episode

### DIFF
--- a/_episodes/09-eia.md
+++ b/_episodes/09-eia.md
@@ -177,7 +177,7 @@ surveys][post-surveys] is difficulty hearing an Instructor from the back of the 
 
 As Instructors, many aspects of our classroom environment are within our control or influence. 
 However, the world is a complicated place, and there will always be extraneous factors that 
-contribute to demotivation and add to cogitive load. These vary from person to person, but 
+contribute to demotivation and add to cognitive load. These vary from person to person, but 
 members of certain groups often carry a heavier load due to systemic forces that disproportionately 
 impact them. What we can control, in this case, is our own awareness of the challenges these forces 
 present to teaching and learning. As with other demotivation pitfalls, we can also


### PR DESCRIPTION
tpying error was removed under the section ## Systemic Exclusion cogitive load was changed to cognitive load

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
instructor.training@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
