### PR TITLE
Align text to images in 04-expertise

### DIFF
--- a/_episodes/04-expertise.md
+++ b/_episodes/04-expertise.md
@@ -64,8 +64,8 @@ The greater connectivity of a mental model allows experts to:
 * jump directly from a problem to its solution
 because there is a direct link between the two in their mind.
 Where a competent practitioner would have to reason
-"A therefore B therefore C therefore D therefore E",
-the expert can go from A to E in a single step ("A therefore E").
+"A therefore B therefore C therefore F",
+the expert can go from A to F in a single step ("A therefore F").
 
 We will expand on some of these below and how they can manifest in the way you teach.
 

--- a/_episodes/04-expertise.md
+++ b/_episodes/04-expertise.md
@@ -77,9 +77,9 @@ to explain what you are doing step-by-step, and how each step leads to the next 
 
 ### Mind The Gap
 
-The problem with this is that when you are used to going from A to E in a single leap, it can 
-be very hard to remember that novices need to go through B, C, and D to understand the 
-connection. Experts are frequently so familiar with their subject 
+The problem with this is that when you are used to going from A to F in a single leap, it can 
+be very hard to remember that novices need to go through steps B and C before they can understand the 
+connection between A and F. Experts are frequently so familiar with their subject 
 that they can no longer imagine what it is like to *not* understand the world that way. 
 This phenomenon is known in the literature as an *expert blind spot*.
 

--- a/_episodes/04-expertise.md
+++ b/_episodes/04-expertise.md
@@ -189,9 +189,8 @@ it with more positive and motivating word choices.
 
 > ## Changing Your Language  
 >
-> 1) What other words or phrases, besides "just", can have the same effect of dismissing the experience of finding a subject difficult or unclear? 
-> 
-> 2) Propose an alternate phrasing for one of the suggestions above.
+> 1. What other words or phrases, besides "just", can have the same effect of dismissing the experience of finding a subject difficult or unclear? 
+> 2. Propose an alternate phrasing for one of the suggestions above.
 > 
 > Write your examples and alternatives in the Etherpad.
 >


### PR DESCRIPTION
A few suggested fixes for episode 04-expertise:

1. fixed steps of reasoning for a competent practitioner (around metal models of people with different skills)

The steps described in the text do not match the diagram (of the mental models of novices/competent practitioners and experts) - we either need to change the diagram or the explanation of it. I've changed the explanation but it may be better to modify the diagram to swap nodes E and F in the diagram.

This was issue with the old curriculum as well, but I never got round to fixing it.

2. list consistency improvement
