### PR TITLE
Adjust mailto: link

### DIFF
--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -103,7 +103,7 @@ The greater challenge, in most cases, is identifying where and how to cut.
 
 
 ### What Comes Next?
-If you submit your own contribution, be sure to send an email with a link to [instructor.training@carpentries.org](mailto: instructor.training@carpentries.org).
+If you submit your own contribution, be sure to send an email with a link to [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).
 Pay attention to GitHub notifications in case the Maintainers or others have follow-up questions or
 requests. However, also keep in mind that Carpentries lesson Maintainers, like Instructors, are mostly volunteers! Some repositories are vigorously
 maintained; others may have slower response times. Do not take it personally if your contribution does not get a prompt response.


### PR DESCRIPTION
Removed the space in the `mailto:` link. Some browsers features for selecting the email address from a mailto: link resulted in a space being mapped to `%20` when used in a preferred email client.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
instructor.training@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
