### PR TITLE
removed blank line in middle of paragraph

### DIFF
--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -221,9 +221,7 @@ work for a checkout demo. Be sure to give yourself time to change course if your
 
 ### Sign-up and Set-up
 To sign up, select a session that works for you on [the Instructor Training Demonstration Sessions Etherpad]({{page.demopad}}), and add
-your name and a link to your lesson of choice to that Etherpad. Be sure to **double check the time in your local time zone** by clicking on the converter
-
-link posted. Also, examine the demo description to ensure that it is not a special session targeting a specific sub-community or
+your name and a link to your lesson of choice to that Etherpad. Be sure to **double check the time in your local time zone** by clicking on the converter link posted. Also, examine the demo description to ensure that it is not a special session targeting a specific sub-community or
 language (unless you are part of that target group).
 
 The link to connect to the video conference is at the top of the Teaching Demos Etherpad. 


### PR DESCRIPTION
Remove the blank line in the middle of the "Sign-up and Set-up" paragra[h.

<img width="2397" alt="Screen Shot 2022-04-06 at 3 17 27 PM" src="https://user-images.githubusercontent.com/32374186/162493813-f919c426-c0bd-454f-b0bf-df3a0c39d9ef.png">

