### PR TITLE
TD Rubric Template

### DIFF
--- a/_extras/demos_rubric.md
+++ b/_extras/demos_rubric.md
@@ -33,24 +33,30 @@ Appears focused and attentive to learners|Appears significantly distracted by co
 
 ---
 
-Trainers can also use the form below to take notes during the teaching demonstration.
+Trainers can also copy the form below to take notes during the teaching demonstration.
 
-Trainee:
+```
+# Teaching Demonstration Notes
 
-Date:
+**Trainee**:
+**Date**:
 
-|Aspect|Comments_________________________________________________|
-|------|---------------------|
-|<br>Sticks to curriculum<br>|
-|<br>Context|
-|<br>Content Knowledge|
-|<br>Mirror learner's environment|
-|<br>Font & window size|
-|<br>Explanation of typing|
-|<br>Embraces & uses mistakes|
-|<br>Use of notes on paper/tablet|
-|<br>Distraction-free screen|
-|<br>Wording|
-|<br>Pacing|
-|<br>Clarity|
-|<br>Demeanor & focus|
+## Content
+
+**Sticks to curriculum**:
+**Context**:
+**Content Knowledge**:
+
+## Delivery
+
+**Mirror learner's environment**:
+**Font & window size**:
+**Explanation of typing**:
+**Embraces & uses mistakes**:
+**Use of notes on paper/tablet**:
+**Distraction-free screen**:
+**Wording**:
+**Pacing**:
+**Clarity**:
+**Demeanor & focus**:
+```

--- a/_extras/demos_rubric.md
+++ b/_extras/demos_rubric.md
@@ -49,6 +49,7 @@ Trainers can also copy the form below to take notes during the teaching demonstr
 
 ## Delivery
 
+**Manual typing:
 **Mirror learner's environment**:
 **Font & window size**:
 **Explanation of typing**:


### PR DESCRIPTION
The first commit changes the rubric form into a code block in markdown format for easy copying into text editors. The way it was, I did not see an easy way to use it (If there is, it could be mentioned instead of this change).

The second commit adds “Manual typing” to that form, the only point that was missing relative to the table above.