### PR TITLE
Update Open Instructor Training rubric

### DIFF
--- a/files/rubric.md
+++ b/files/rubric.md
@@ -18,7 +18,9 @@
 
 - Award +1 for using tools "every day" or "a few times a week".
 
-- Award +4 for meeting criteria for current recruitment push. As of August 2021, active recruitment areas are:
-     - EukRef community members   
+- Award points for meeting criteria for current recruitment push. As of April 2022, active recruitment areas are:
+     - EukRef community members  (+4) 
+     - Applicants willing to teach Centrally Organised Workshops (+4)
+     - Humanities, Library & information sciences, Economics/business, Social Sciences, Chemistry (+1)
 
 - Award -3 to +3 based on free text responses.


### PR DESCRIPTION
Addition of points for teaching centrally organised workshops was approved by Trainers Leadership at April 13 meeting. 

Other changes here reflect prior point structures that have not been removed from automated scoring due to lags in updating our database. We expect continued delays there, so adding these categories back in to the rubric to accurately reflect the current scoring system. (New categories with added points will be scored manually, but it is harder to remove points that have been automatically assigned.)

