### PR TITLE
Replace "instructor-of-record" with better understandable term

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -91,7 +91,7 @@ Now, we would like to get to know all of you.
 > 1.  I have been a graduate or undergraduate teaching assistant for a university/college course.
 > 2.  I have not had any teaching experience in the past.
 > 3.  I have taught a seminar, workshop, or other short or informal course.
-> 4.  I have been the instructor-of-record for my own university/college course.
+> 4.  I have been the main/responsible teacher for a course at my own university/college course.
 > 5.  I have taught at the primary or secondary education level.
 > 6.  I have taught informally through outreach programs, hackathons, libraries, laboratory demonstrations, and similar activities.
 >


### PR DESCRIPTION
I suggest to replace "instructor-of-record" with main/responsible teacher, or a similar, more universally understandable term.
At our recent instructor training, no-one knew what an "instructor of record" was. We discussed this briefly and thought that person would not have much responsibility, and when someone checked we were surprised to find out that this is the main responsible teacher. This seems to be a term that is only used in some parts of the world (US, maybe?). Participants of the training were mainly from Europe, Middle East, India/Pakistan and Africa.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
instructor.training@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
