### PR TITLE
fix mailto links to CommonMark spec

### DIFF
--- a/_episodes/14-checkout.md
+++ b/_episodes/14-checkout.md
@@ -19,13 +19,13 @@ need to take after this training to become a fully certified Carpentries Instruc
 After completing the Instructor Training workshop, there are three final steps to complete before qualifying as an Instructor. 
 Briefly, the three steps are:
 
-1.  Make (and [send us a link](mailto: instructor.training@carpentries.org) to) a small contribution to a lesson or glossary.
+1.  Make (and [send us a link](mailto:instructor.training@carpentries.org) to) a small contribution to a lesson or glossary.
 2.  Take part in an online community discussion session.
 3.  Take part in an online teaching demonstration session.
 
 
 All trainees have 3 months (90 days) from the end date of your training to complete checkout. If you need more time,
-3-month extensions may be requested by emailing [instructor.training@carpentries.org](mailto: instructor.training@carpentries.org). 
+3-month extensions may be requested by emailing [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org). 
 Extensions may be granted for any reason up to 1 year from your training date.
 
 

--- a/_extras/additional_exercises.md
+++ b/_extras/additional_exercises.md
@@ -145,7 +145,7 @@ Learner profiles have three parts:
 > "Issues" tab. Read through some of the discussions and, if you have anything to add, please add it
 > to the conversation! If you wish to make a pull request, be sure to examine the contribution guidelines for
 > the repository you are working in. If you do make a significant contribution to the discussion, send a link to
-> the issue to [checkout@carpentries.org](mailto: checkout@carpentries.org). Congratulations! You have
+> the issue to [checkout@carpentries.org](mailto:checkout@carpentries.org). Congratulations! You have
 > just completed one of the three remaining steps in becoming a Carpentries Instructor.
 >
 > Leave about 5-10 minutes for this exercise.

--- a/_extras/additional_exercises.md
+++ b/_extras/additional_exercises.md
@@ -145,7 +145,7 @@ Learner profiles have three parts:
 > "Issues" tab. Read through some of the discussions and, if you have anything to add, please add it
 > to the conversation! If you wish to make a pull request, be sure to examine the contribution guidelines for
 > the repository you are working in. If you do make a significant contribution to the discussion, send a link to
-> the issue to [checkout@carpentries.org](mailto:checkout@carpentries.org). Congratulations! You have
+> the issue to [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org). Congratulations! You have
 > just completed one of the three remaining steps in becoming a Carpentries Instructor.
 >
 > Leave about 5-10 minutes for this exercise.

--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -18,7 +18,7 @@ Briefly, the three steps are:
 
 
 All trainees have 3 months (90 days) from the end date of your training to complete checkout. If you need more time,
-3-month extensions may be requested by emailing [instructor.training@carpentries.org](mailto: instructor.training@carpentries.org).
+3-month extensions may be requested by emailing [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).
 Extensions may be granted for any reason up to 1 year from your training date.
 
 ## 1. Lesson Contributions
@@ -69,7 +69,7 @@ All Carpentries curricula (including this one) are hosted on GitHub. Learning to
 including the ability to contribute to other open-source projects! However, we understand that there are many
 reasons why trainees may wish to avoid engaging on GitHub. That's ok!
 
-For this checkout task, you may email your contribution to [instructor.training@carpentries.org](mailto: instructor.training@carpentries.org).
+For this checkout task, you may email your contribution to [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).
 Be sure to include a link to the lesson or site that you are addressing in your contribution. A Carpentries Core Team member will
 add your contribution to the relevant repository on your behalf (e.g. by creating an issue), and will send you a link so that
 you may view any responses by the maintainers.
@@ -180,7 +180,7 @@ indicate that you are completing checkout and attend the event you are signed up
 Community Discussion meeting.
 
 If you attend an in-person meeting or a CarpentryCon/Connect event, please verify with your host if they plan to report checkout attendance. If you are
-not sure whether your attendance has been reported, you can email us at [instructor.training@carpentries.org](mailto: instructor.training@carpentries.org) to confirm.
+not sure whether your attendance has been reported, you can email us at [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org) to confirm.
 
 ## 3. Teaching Demonstration
 
@@ -252,7 +252,7 @@ After your instructor training workshop, Carpentries Core Team members will use 
 your profile in The
 Carpentries database, AMY. You can monitor your checkout progress by [logging on to our database, AMY][amy-login], using your GitHub username.
 If you have any questions or did not provide a GitHub username in your form, please email us 
-at [instructor.training@carpentries.org](mailto: instructor.training@carpentries.org).
+at [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).
 
 Keeping [your profile][trainee-profile] up to date with a current email address and local airport helps us to keep in touch about teaching
 opportunities. You may also adjust your preferences to select whether you want to have your profile shared on our

--- a/setup.md
+++ b/setup.md
@@ -37,7 +37,7 @@ in all of the practical exercises (a tablet will not be sufficient).
 After this course is over, you will be asked to do three short follow-up exercises online 
 in order to finish certification as an Instructor: the details are available on the [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout/index.html). 
   
-If you have any questions about the workshop, the reading material, or anything else, please [email us](mailto: instructor.training@carpentries.org)!
+If you have any questions about the workshop, the reading material, or anything else, please [email us](mailto:instructor.training@carpentries.org)!
 
 
 Recommended Episodes


### PR DESCRIPTION
There are several mailto links that do not conform to CommonMark spec because they have an unescaped space between `mailto:` and the email (see https://github.com/ropensci/tinkr/issues/68 for more details)

If you [look at a markdown document on github with a malformed mailto link, it shows up as raw markdown](https://github.com/carpentries/instructor-training/blob/gh-pages/_episodes/14-checkout.md#instructor-checkout).

The reason why Jekyll doesn't catch it is because it is based on a variant of markdown that is not based on CommonMark. 

This will help me immensely in my conversions of the lesson.
