### PR TITLE
Reorder solutions

### DIFF
--- a/_episodes/23-introductions.md
+++ b/_episodes/23-introductions.md
@@ -186,16 +186,16 @@ there are far more valuable ways to spend the last 15-20 minutes of a course tha
 > > - Plan next steps. Does the local community have resources to support continued learning? 
 > > Do you have advice for how learners might continue on their own? Even
 > > if you have no advice, asking learners to take a moment to discuss their own plans can support them in taking a next step sooner rather than later.
+> > - Reiterate where the lesson materials can be found, and encourage them to apply at least one of the skills to their own work within the next few days.  Some examples could be:
+> >    - Recreate an spreadsheet from a past presentation in R
+> >    - Write a lab notebook entry in R-markdown
+> >    - Backup a thesis or manuscript by storing it on a version control server
+> >    - Log in to a remote machine and run an analysis there
 > > - Collect feedback. Minute cards, one-up-one-down, and making time for Carpentries post-assessment surveys will support your continuing development as an 
 > > Instructor as well as our continuing development of Carpentries programs. This can also support or complement a reflection activity.
 > > - Check with the workshop host to see if they have any closing words or instructions they would like to share.
 > > - Celebrate everyone's hard work. Thank your learners for helping each other, for staying motivated and persevering with you! Thank your helpers -- keep a
 > > list of names handy if you might forget them. Enjoy the applause, and give everyone a moment to bask in praise for a job well done.
-> > Reiterate where the lesson materials can be found, and encourage them to apply at least one of the skills to their own work within the next few days.  Some examples could be:
-> >    - Recreate an spreadsheet from a past presentation in R
-> >    - Write a lab notebook entry in R-markdown
-> >    - Backup a thesis or manuscript by storing it on a version control server
-> >    - Log in to a remote machine and run an analysis there
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
This PR moves the suggested item up in the list to be grouped with other follow-up type things and leave "celebrate" for last. It also adds a bullet for this item. I'm not sure that the list will actually render sub-bullets, so it may be desirable to strip some of the detail here. However, I'm not too concerned at the moment because I think many of these "solutions" boxes will end up being re-done with in-line Instructor Notes in the workbench.