### PR TITLE
Make time references to 4 parts, not 2 days

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -19,14 +19,14 @@ keypoints:
 ---
 
 > ## Pronouns and Names
-> 
+>
 > Using correct names and pronouns (e.g. "she/her") is important for setting a respectful tone. Learning these is hard to
-> do quickly, so we recommend displaying it prominently during the workshop. 
-> 
-> In an online workshop, give everyone a moment to update their display name to reflect how they would like to be addressed. 
-> 
+> do quickly, so we recommend displaying it prominently during the workshop.
+>
+> In an online workshop, give everyone a moment to update their display name to reflect how they would like to be addressed.
+>
 > At an in-person event, we recommend supplying name tags and markers, or using plain paper to create table-displayed name placards.
-> 
+>
 > Note that pronouns are personal and some participants might prefer not to share them.
 > Do not force people to share their pronouns.
 {: .discussion}
@@ -47,8 +47,8 @@ A different kind of "icebreaker." Photo credit: Grand-Duc, Wikipedia, http://en.
 ## Code of Conduct
 
 To make clear what is expected, everyone participating in The Carpentries activities is required
-to abide by our [Code of Conduct][coc]. Any form of behaviour to exclude, intimidate, 
-or cause discomfort is a violation of the Code of Conduct. In order to foster a positive and professional 
+to abide by our [Code of Conduct][coc]. Any form of behaviour to exclude, intimidate,
+or cause discomfort is a violation of the Code of Conduct. In order to foster a positive and professional
 learning environment we encourage you to:  
 * Use welcoming and inclusive language
 * Be respectful of different viewpoints and experiences
@@ -56,14 +56,14 @@ learning environment we encourage you to:
 * Focus on what is best for the community
 * Show courtesy and respect towards other community members
 
-If you believe someone is violating the Code of Conduct, we ask that you report it to The Carpentries 
+If you believe someone is violating the Code of Conduct, we ask that you report it to The Carpentries
 Code of Conduct Committee by completing [this form](https://goo.gl/forms/KoUfO53Za3apOuOK2).
 
 ## Introductions
 Hello everyone, and welcome to The Carpentries
 instructor training.  We are very pleased to have you with us.
 
-> ## Today's Trainers
+> ## This Event's Trainers
 >
 > To begin class, each Trainer should give a brief introduction of themselves.
 >
@@ -75,7 +75,7 @@ Now, we would like to get to know all of you.
 
 > ## Reviewing The Carpentries Experience and Goals
 >
-> For the multiple choice questions below, please place an "X" next to the response(s) that best apply to you. Then find yourself a spot 
+> For the multiple choice questions below, please place an "X" next to the response(s) that best apply to you. Then find yourself a spot
 > in the Etherpad below to write a short response to the last question.
 >
 > *Have you ever participated in a Software Carpentry, Data Carpentry, or Library Carpentry Workshop?*
@@ -95,7 +95,7 @@ Now, we would like to get to know all of you.
 > 5.  I have taught at the primary or secondary education level.
 > 6.  I have taught informally through outreach programs, hackathons, libraries, laboratory demonstrations, and similar activities.
 >
-> **Why are you taking this course? What goals do you have for today and tomorrow?**
+> **Why are you taking this course? What goals do you have for this training?**
 >
 > This exercise should take about 5 minutes for responses, with an optional 10 for additional discussion as time permits.
 {: .challenge}
@@ -155,29 +155,29 @@ We will have many opportunities to practice and give each other feedback through
 ### Creating a Positive Learning Environment
 
 One part of making this a productive experience for all of us is a
-community effort to treat one another with kindness and respect.  The [Code of Conduct]({{ site.coc }}) 
+community effort to treat one another with kindness and respect.  The [Code of Conduct]({{ site.coc }})
 is one piece of this. We will also be discussing and practicing teaching techniques to create a positive and
 welcoming environment in your classrooms, and will spend some time talking about why this is important.
 
 ### The Carpentries History and Culture
 
 In addition to the teaching practices and philosophy that have been
-adopted by The Carpentries community, it is helpful to become familiar 
-with our community structure and organisational procedures as you 
+adopted by The Carpentries community, it is helpful to become familiar
+with our community structure and organisational procedures as you
 prepare to join our Instructor community.
 The greatest asset of The Carpentries is people like
-you - people who want to help researchers learn new skills 
+you - people who want to help researchers learn new skills
 and share their own experience and enthusiasm.  Meeting your fellow trainees and
-Instructor Trainers at today's event is your first step into The Carpentries community.
+Instructor Trainers at this event is your first step into The Carpentries community.
 
 ## What We Leave Out
 
 We will **not** be going over Data Carpentry, Library Carpentry, or Software Carpentry workshop content in detail (although you will gain
 familiarity with some of the content through the exercises),
 This workshop is a significant requirement for becoming a certified Carpentries Instructor.
-The additional steps for certification, called _Checkout_, will require that you dig into the workshop content yourself. We will talk about that more tomorrow afternoon.
+The additional steps for certification, called _Checkout_, will require that you dig into the workshop content yourself. We will talk about checkout requirements more in part 3 of this training.
 
-We also do not discuss *how* to develop lessons, although we do mention some aspects of lesson design. We include this information to help you as an instructor identify the important components of lessons for high impact, inclusive teaching. The Carpentries now has a growing subcommunity dedicated to lesson development, 
+We also do not discuss *how* to develop lessons, although we do mention some aspects of lesson design. We include this information to help you as an instructor identify the important components of lessons for high impact, inclusive teaching. The Carpentries now has a growing subcommunity dedicated to lesson development,
 along with [its own onboarding curriculum][lesson-dev]. For more on lesson development, see [The Carpentries website][lesson-dev-web].
 
 If there is a particular topic that you would like us to address, let the Trainers
@@ -186,11 +186,11 @@ know.
 ## What Questions Do You Have?
 
 We hope and expect that you will have many questions during this training! Please do not
-keep them to yourself. If you find something unclear, chances are good that others will have the same question, too. 
+keep them to yourself. If you find something unclear, chances are good that others will have the same question, too.
 It is ok to ask even if you think you might have missed an answer already given
 (e.g. during a distracted moment or a dropped connection)!
-Depending on the time available, your Trainers may ask you to share your questions 
-verbally, in the Etherpad, or otherwise. 
+Depending on the time available, your Trainers may ask you to share your questions
+verbally, in the Etherpad, or otherwise.
 
 Now that we have a road map of what we are covering
 we are ready to begin our training. Our goal is that by the end, you will

--- a/_episodes/03-coffee.md
+++ b/_episodes/03-coffee.md
@@ -1,6 +1,6 @@
 ---
 layout: break
-title: "Morning Break"
+title: "Part 1 Break"
 teaching: 0
 exercises: 0
 break: 15

--- a/_episodes/06-feedback.md
+++ b/_episodes/06-feedback.md
@@ -69,7 +69,7 @@ opportunity to reflect), yourself (you will get more useful feedback), and The C
 
 ## Minute Cards
 
-During any lunch breaks and between days, we
+Before each long break, for example lunch or between days, we
 have learners complete **minute cards** to share anonymous feedback. At an in-person workshop,
 paper sticky notes double as minute cards, with the two different colors used for positive and
 constructive feedback. At an online workshop, this may be done by making a copy of our [Virtual Minute Card Template](https://docs.google.com/forms/d/1p7iOV5HNvy4POS4g6eottY8RSfKq4kaoKz1-jIFYTMI/template/preview)

--- a/_episodes/06-feedback.md
+++ b/_episodes/06-feedback.md
@@ -60,7 +60,7 @@ a dashboard with the results! Take care not to share this link with your learner
 
 We have found that learners are much more likely to fill out the post-workshop survey
 while they are still at the workshop than they are after they leave the venue. At the end
-of a two-day workshop, your learners' brains will be very tired. Rather than trying to
+of a multi-day workshop, your learners' brains will be very tired. Rather than trying to
 fit in another 15 minutes worth of teaching, give your learners time to complete the
 post-workshop survey at the end of your workshop. You will be helping them (with an
 opportunity to reflect), yourself (you will get more useful feedback), and The Carpentries
@@ -69,7 +69,7 @@ opportunity to reflect), yourself (you will get more useful feedback), and The C
 
 ## Minute Cards
 
-Before each lunch break and at the end of the first day, we
+During any lunch breaks and between days, we
 have learners complete **minute cards** to share anonymous feedback. At an in-person workshop,
 paper sticky notes double as minute cards, with the two different colors used for positive and
 constructive feedback. At an online workshop, this may be done by making a copy of our [Virtual Minute Card Template](https://docs.google.com/forms/d/1p7iOV5HNvy4POS4g6eottY8RSfKq4kaoKz1-jIFYTMI/template/preview)
@@ -88,7 +88,7 @@ Whatever method you use, you may wish to customize the prompt to elicit differen
 - One thing that is confusing / you would like clarification on.    
 - One question you have
 
-Over lunch and before the second day starts, the Instructors read through the minute
+During any lunch breaks and between days, the Instructors read through the minute
 cards and look for patterns. At the start of each half day, the Instructors
 take a few minutes to address commonly raised issues with the whole class. The
 non-teaching Instructor can also type answers to the questions in the Etherpad.

--- a/_episodes/06-feedback.md
+++ b/_episodes/06-feedback.md
@@ -14,20 +14,20 @@ keypoints:
 - "Take the time to respond to your learners' feedback."
 ---
 
-We use formative assessment of learners during workshops to help track 
+We use formative assessment of learners during workshops to help track
 learners' progress and adjust our approach to teaching the content as needed.
-But formative assessment is not just for learners. As we will discuss in more detail 
-[later]({{ page.root }}/11-practice-teaching/), teaching is also a skill that is improved 
+But formative assessment is not just for learners. As we will discuss in more detail
+[later]({{ page.root }}/11-practice-teaching/), teaching is also a skill that is improved
 through regular practice and feedback. We gather feedback from our learners
-at multiple points in the workshop and in different forms. 
+at multiple points in the workshop and in different forms.
 
 ## Surveys
 
-Carpentries learners fill out a survey before attending and immediately after a workshop. 
+Carpentries learners fill out a survey before attending and immediately after a workshop.
 These surveys include questions to help instructors get an idea of their attendees' prior
 experience and backgrounds before the workshop starts. Using this information, instructors
 can start to plan how they will approach the materials and what level of exercises
-are likely to be appropriate for their learners. 
+are likely to be appropriate for their learners.
 
 You can preview the surveys your learners will take at the links below:
 
@@ -57,44 +57,44 @@ a dashboard with the results! Take care not to share this link with your learner
 ![Screenshot of a workshop website showing location of customized survey links](../fig/surveyscreenshot3.svg)
 
 ### Timing Matters
- 
+
 We have found that learners are much more likely to fill out the post-workshop survey
-while they are still at the workshop than they are after they leave the venue. At the end 
-of a two-day workshop, your learners' brains will be very tired. Rather than trying to 
+while they are still at the workshop than they are after they leave the venue. At the end
+of a two-day workshop, your learners' brains will be very tired. Rather than trying to
 fit in another 15 minutes worth of teaching, give your learners time to complete the
 post-workshop survey at the end of your workshop. You will be helping them (with an
-opportunity to reflect), yourself (you will get more useful feedback), and The Carpentries 
+opportunity to reflect), yourself (you will get more useful feedback), and The Carpentries
 (we improve our programs based on feedback, and our funders take pride in the success of our workshops, too).
 
 
 ## Minute Cards
 
 Before each lunch break and at the end of the first day, we
-have learners complete **minute cards** to share anonymous feedback. At an in-person workshop, 
-paper sticky notes double as minute cards, with the two different colors used for positive and 
+have learners complete **minute cards** to share anonymous feedback. At an in-person workshop,
+paper sticky notes double as minute cards, with the two different colors used for positive and
 constructive feedback. At an online workshop, this may be done by making a copy of our [Virtual Minute Card Template](https://docs.google.com/forms/d/1p7iOV5HNvy4POS4g6eottY8RSfKq4kaoKz1-jIFYTMI/template/preview)
-on Google Forms. Other tools can work as well, but we do recommend making sure that feedback is private and 
+on Google Forms. Other tools can work as well, but we do recommend making sure that feedback is private and
 anonymous. A public-facing sticky note board will receive different (and less useful) feedback.
 
-Whatever method you use, you may wish to customize the prompt to elicit different types of feedback at each break. 
+Whatever method you use, you may wish to customize the prompt to elicit different types of feedback at each break.
 
 **Example positive prompts:**   
 - One thing you liked about this section of the workshop
 - The most important thing you learned today   
-- A new skill, command, or technique you are most excited about using 
+- A new skill, command, or technique you are most excited about using
 
 **Example constructive prompts:**  
 - One thing you did not like or would change about this section of the workshop
 - One thing that is confusing / you would like clarification on.    
-- One question you have 
+- One question you have
 
-Over lunch and before the second day starts, the Instructors read through the minute 
-cards and look for patterns. At the start of day two and each afternoon, the Instructors
-take a few minutes to address commonly raised issues with the whole class. The 
+Over lunch and before the second day starts, the Instructors read through the minute
+cards and look for patterns. At the start of each half day, the Instructors
+take a few minutes to address commonly raised issues with the whole class. The
 non-teaching Instructor can also type answers to the questions in the Etherpad.
 
 > ## Be Explicit About Using Feedback
-> 
+>
 > Learners are more likely to give useful feedback if they feel that their feedback
 > is being taken seriously. Spending a few minutes talking about the feedback you got
 > and being explicit about what changes you are making in light of that feedback
@@ -119,7 +119,7 @@ about how you are responding to learner feedback.
 
 > ## Give Us Feedback
 >
-> Write one thing you learned this morning that you found useful on
+> Write one thing you learned this so far in this training that you found useful on
 > your blue sticky note, and one question you have about the material
 > on the yellow.  Do *not* put your name on the notes: this is meant to
 > be anonymous feedback.  Add your notes to the pile by the door as

--- a/_episodes/06-feedback.md
+++ b/_episodes/06-feedback.md
@@ -88,7 +88,7 @@ Whatever method you use, you may wish to customize the prompt to elicit differen
 - One thing that is confusing / you would like clarification on.    
 - One question you have
 
-During any lunch breaks and between days, the Instructors read through the minute
+During long breaks, instructors read through the minute
 cards and look for patterns. At the start of each half day, the Instructors
 take a few minutes to address commonly raised issues with the whole class. The
 non-teaching Instructor can also type answers to the questions in the Etherpad.

--- a/_episodes/07-lunch.md
+++ b/_episodes/07-lunch.md
@@ -1,6 +1,6 @@
 ---
 layout: break
-title: "End First Half Day"
+title: "End Part 1"
 teaching: 0
 exercises: 0
 break: 60

--- a/_episodes/09-eia.md
+++ b/_episodes/09-eia.md
@@ -262,7 +262,8 @@ to all that the instructional team cares about their experience, creating
 an environment that is explicitly inclusive and supports safe focus 
 on learning.
 
-We will discuss the Code of Conduct in greater detail tomorrow.
+We will discuss the Code of Conduct in greater detail in Part 4 of this training during
+our discussion of Working with your team.
 
 ### Listening with Assessment and Feedback
 

--- a/_episodes/10-coffee.md
+++ b/_episodes/10-coffee.md
@@ -1,6 +1,6 @@
 ---
 layout: break
-title: "Afternoon Break"
+title: "Part 2 Break"
 teaching: 0
 exercises: 0
 break: 15

--- a/_episodes/11-practice-teaching.md
+++ b/_episodes/11-practice-teaching.md
@@ -195,15 +195,15 @@ Now that you have had some practice observing teaching and giving feedback, let 
 > 3.  Get together with your group and have one person teach their segment to the group.
 >     Keep a strict time limit of 90 seconds per person (one person
 >     should be responsible for the timekeeping).
-> 4.  After the first person has finished teaching, share feedback. The person who performed 
->     should start by offering feedback on themselves. The timekeeper should help to keep 
+> 4.  After the first person has finished teaching, share feedback. The person who performed
+>     should start by offering feedback on themselves. The timekeeper should help to keep
 >     feedback to about 5 minutes per person to ensure everyone has time to perform and discuss.
 > 5.  Rotate roles and repeat steps 3 & 4
 > 5.  Return to the main group and briefly summarize the feedback you received in the Etherpad.
 > Your Trainer will split the group into virtual break-out rooms. Follow the instructions above
 > but do not record each other. Instead, give each person feedback immediately after they finish their
 > turn teaching.
-> 
+>
 > **Trainings where trainees are co-located:**
 > 1.  Split into groups of three.
 > 2.  Individually, spend 5 minutes preparing a 90-second introduction to the topic of
@@ -253,7 +253,7 @@ If you notice yourself feeling hurt or threatened by the feedback you got, or re
 pause and try to consider the feedback from a growth mindset - that through practice and feedback, your skills
 are going to improve. By strengthening your growth mindset with respect to teaching, you can
 transform getting feedback from an unpleasant experience to a richly rewarding one. You will have more opportunities to
-practice teaching and to get and give feedback tomorrow.
+practice teaching and to get and give feedback in parts 3 and 4.
 
 
 [lunar-babboon]: https://web.archive.org/web/20210513225525/http://www.lunarbaboon.com/comics/feedback.html

--- a/_episodes/12-homework.md
+++ b/_episodes/12-homework.md
@@ -1,5 +1,5 @@
 ---
-title: "Wrap-Up and Homework"
+title: "End Part 2 and Homework"
 teaching: 5
 exercises: 15
 questions:
@@ -10,26 +10,26 @@ objectives:
 - "Produce a paragraph, drawing, or diagram that summarizes what was taught to this point."  
 keypoints:
 - "So far, we have learned about how people learn, how to build a positive classroom environment, and how to give feedback."
-- "Tomorrow we will cover specifics of Carpentries workshops and teaching practices."
+- "In parts 3 and 4 we will cover specifics of Carpentries workshops and teaching practices."
 ---
 
 In the first half of this workshop we have focused on understanding some core findings of pedagogical research about how the learning process
 works and the importance of creating a positive classroom environment. We also introduced the idea of lesson study
-and gave some opportunities to practice teaching. Tomorrow we will continue our discussions of
+and gave some opportunities to practice teaching. In the remaining parts of the training, we will continue our discussions of
 how we build teaching skill and will have more chances for practice and feedback. We will also
 look in some depth at how The Carpentries operates to prepare you for the logistics of teaching a workshop.
 
-To prepare for tomorrow, please:
+To prepare for our next session, please:
 
 1.  Read about [centrally-organized and self-organized workshops](https://carpentries.org/workshops/#workshop-organising) and our handbook content on [Teaching and Hosting Workshops](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html) -- be sure to click through to some of the associated checklists. These summarize commonly asked questions about organizing and running workshops.
-    When you arrive tomorrow, we will ask you to add one question about our operations to a list.
+    When you arrive for the next part, we will ask you to add one question about our operations to a list.
     We will then do our best to answer all of those questions during the day.
 
 2.  Prepare for the [live coding exercises]({{ page.root }}/17-live/).
-    If you have not already done so per the pre-workshop instructions, pick an episode from an existing Software Carpentry, 
-    Data Carpentry, or Library Carpentry lesson and 
+    If you have not already done so per the pre-workshop instructions, pick an episode from an existing Software Carpentry,
+    Data Carpentry, or Library Carpentry lesson and
     read through it carefully.
-    Tomorrow, you will use this to practice live coding/participatory instruction for 3 minutes. 
+    In the next two parts, you will use this to practice live coding/participatory instruction for 3 minutes.
     Remember, imperfect presentations can generate useful feedback!
     If you have not yet selected an episode to focus on and would like a recommendation, consider one of the following:
     *   Data Carpentry
@@ -37,12 +37,12 @@ To prepare for tomorrow, please:
         *   [Basic Queries in SQL](<{{ site.dc_site }}/sql-ecology-lesson/01-sql-basic-queries/>)
         *   [Starting with Data in R](<{{ site.dc_site }}/R-ecology-lesson/02-starting-with-data.html>)
         *   [Starting with Data in Python](<{{ site.dc_site }}/python-ecology-lesson/02-starting-with-data/>)
-        
+
     *   Library Carpentry
         *   [Working with Files and Directories in the Unix Shell](https://librarycarpentry.github.io/lc-shell/03-working-with-files-and-folders/index.html)
         *   [Faceting and filtering in Open Refine](https://librarycarpentry.github.io/lc-open-refine/04-faceting-and-filtering/index.html)
         *   [For loops in Python](https://librarycarpentry.github.io/lc-python-intro/12-for-loops/index.html)        
-        
+
     *   Software Carpentry
         *   [Working with Files and Directories in the Unix Shell](<{{ site.swc_pages }}/shell-novice/03-create/>)
         *   [Tracking Changes in Git](<{{ site.swc_pages }}/git-novice/04-changes/>)
@@ -73,7 +73,7 @@ To prepare for tomorrow, please:
 > * draw pictures or a comic depicting one of the day's concepts
 > * write an outline of the topics we covered
 > * write a paragraph or “journal” entry about your
-> experience of the training today
+> experience of the training so far
 > * write down one thing that struck you the most
 >
 > This exercise should take about 10 minutes.

--- a/_episodes/13-second-welcome.md
+++ b/_episodes/13-second-welcome.md
@@ -5,10 +5,10 @@ teaching: 5
 exercises: 5
 questions:
 - "What have we learned so far?"
-- "What will we focus on today?"
+- "What will we focus on next?"
 objectives:
-- "Review main points we discussed yesterday."
-- "Introduce topics we will discuss today."
+- "Review main points we discussed in parts 1 and 2."
+- "Introduce topics we will discuss in parts 3 and 4."
 keypoints:
 - "Instructors guide learners to construct the proper big picture (accurate mental model) of the topic rather than focus on details."
 - "Instructors rely on frequent feedback from learners to monitor their own presentation of the material."
@@ -32,22 +32,22 @@ So far we have focused on general aspects of educational psychology and pedagogy
 how to create a positive classroom as environment, addressing the first two goals.
 We started to address the third goal by discussing the importance of lesson study
 and observation, and by providing an opportunity to teach and
-receive feedback. We will continue that skill development process today, as we
+receive feedback. We will continue that skill development process in Part 3 and 4, as we
 focus on the specifics of teaching Software Carpentry, Data Carpentry, and Library Carpentry workshops.
 We will review specific
 teaching practices we follow at our workshops and practice using some of them. One of the most important practices
 in The Carpentries is participatory live coding.  We will spend some time practicing this skill for multiple reasons:
 one, you rarely find this approach in a current university setting so it is good
 to try it out, but also, this will give us a chance to continue developing skills
-we discussed yesterday that help improve our teaching: reflective practice and
-providing (and receiving!) constructive feedback. In the final sections of the workshop, 
+we discussed so far that help improve our teaching: reflective practice and
+providing (and receiving!) constructive feedback. In the final sections of the workshop,
 we will conclude our training with a discussion about workshop logistics that will help you in preparing to teach your first workshop and become involved in The Carpentries community.
 
 > ## Questions
 >
-> Yesterday we asked you to read some resources about the logistics of teaching and running Carpentries workshops. Please
+> At the end of part 2, we asked you to read some resources about the logistics of teaching and running Carpentries workshops. Please
 > add your questions about logistics and preparation to the Etherpad. We will answer these questions in the Etherpad during your work time
-> and will return to this list later today.
+> and will return to this list later in the training.
 >
 > This activity should take about 5 minutes.
 {: .challenge}

--- a/_episodes/16-coffee.md
+++ b/_episodes/16-coffee.md
@@ -1,6 +1,6 @@
 ---
 layout: break
-title: "Morning Break"
+title: "Part 3 Break"
 teaching: 0
 exercises: 0
 break: 15

--- a/_episodes/17-live.md
+++ b/_episodes/17-live.md
@@ -21,7 +21,7 @@ coding: *instructors do not use slides to teach coding*, but work through the le
 typing in the code or instructions, with the workshop participants following
 along. This section explains how it works, why we use it, and
 gives general tips for an effective participatory live coding presentation. We will
-finish this section by practicing ourselves and providing feedback for each other. 
+finish this section by practicing ourselves and providing feedback for each other.
 
 ## Why Participatory Live Coding?
 
@@ -132,10 +132,10 @@ Read more in [Ten quick tips for teaching with participatory live-coding][live-c
 > 2. Have each group member teach 3 minutes of your chosen lesson episode using live coding.
 >   For this exercise, your peers will not "code-along." Before
 >   you begin, briefly describe what you will be teaching and what has been learned previously. Do not record this exercise.
-> 3. After each person finishes, each group member should share feedback (starting with themselves) using the same 2x2 rubric as yesterday. The
+> 3. After each person finishes, each group member should share feedback (starting with themselves) using the same 2x2 rubric introduced in part 2 The
 > timekeeper should keep feedback discussion to about 1 minute per person; this may leave some time at the end for general
 > discussion. The note-taker should record feedback in the Etherpad.
-> 4. Trade off roles. 
+> 4. Trade off roles.
 >
 > This exercise should take about 25 minutes.  
 {: .challenge}

--- a/_episodes/18-preparation.md
+++ b/_episodes/18-preparation.md
@@ -15,29 +15,29 @@ keypoints:
 - "A good exercise informs Learners and Instructors when an objective is achieved."
 ---
 ## Building Teaching Skill
-In this training, we have discussed many cognitive principles and teaching practices that guide the design and 
+In this training, we have discussed many cognitive principles and teaching practices that guide the design and
 implementation of Carpentries Workshops.
-We hope you are feeling excited and optimistic about putting 
-those concepts to work! 
-One thing we have emphasized is that **teaching is a skill** - and a complex one at that. 
-Whether you are new to teaching or skilled in certain methods, adding new features takes takes time, effort, and deliberate practice. In this episode, 
+We hope you are feeling excited and optimistic about putting
+those concepts to work!
+One thing we have emphasized is that **teaching is a skill** - and a complex one at that.
+Whether you are new to teaching or skilled in certain methods, adding new features takes takes time, effort, and deliberate practice. In this episode,
 we will walk through some suggestions about how to prepare yourself for success in the classroom.
 
-As in other sections, we will not discuss technical preparation. Carefully reviewing the content of your workshop is important! 
+As in other sections, we will not discuss technical preparation. Carefully reviewing the content of your workshop is important!
 However, **it is common for new Instructors to
-over-prepare on technical content** -- which can be endless! -- and under-prepare the 
-learner-centered elements of their teaching practice. If you encounter questions that you can't answer, 
+over-prepare on technical content** -- which can be endless! -- and under-prepare the
+learner-centered elements of their teaching practice. If you encounter questions that you can't answer,
 demonstrating how you Google things may earn surprisingly positive feedback! In contrast, neglecting
-to attend to the audience usually has much more serious consequences for learning and morale. When you prepare to teach, 
-we therefore suggest setting aside time *before* deeply reviewing your technical content to **plan your approach to instruction**. 
+to attend to the audience usually has much more serious consequences for learning and morale. When you prepare to teach,
+we therefore suggest setting aside time *before* deeply reviewing your technical content to **plan your approach to instruction**.
 
 > ## A note on cutting
 >  
-> This episode is a common place to Trainers to cut while preparing to teach. 
->  That's not because this is not important -- this page is a valuable resource -- but we feel this 
+> This episode is a common place to Trainers to cut while preparing to teach.
+>  That's not because this is not important -- this page is a valuable resource -- but we feel this
 >  is one of the sections that trainees can use effectively as a resource when actually preparing
-> for a workshop, even without spending a lot of time doing activities on this material during 
-> their Instructor Training event. 
+> for a workshop, even without spending a lot of time doing activities on this material during
+> their Instructor Training event.
 >
 {: .callout}
 
@@ -45,44 +45,44 @@ we therefore suggest setting aside time *before* deeply reviewing your technical
 ## Anticipate Your Audience
 
 To teach effectively, you have to know *who* you are teaching. You may have a broad idea about the type of audience you expect. You may
-(we hope!) have a plan to learn a few things about your participants after a class has begun. However, in thinking about your learners, it is 
+(we hope!) have a plan to learn a few things about your participants after a class has begun. However, in thinking about your learners, it is
 also important to consider the broader contexts they bring in ways that you will never get to fully explore in your classroom. It can be helpful
-to reserve time to think through ways in which learners' experiences and needs may be similar to or different from your own, or from each others. 
+to reserve time to think through ways in which learners' experiences and needs may be similar to or different from your own, or from each others.
 
 ![A tree diagram of Carpentries instruction and audience in which Instructor Trainers teach Instructors and Instructors teach Learners](../fig/instructor-training-program.png)
 
 
 > ## Imagine a Learner
 >
-> Take a moment to silently imagine a learner who might attend your workshop. What is their background? What problem do they face? 
-> What will they gain from attending your workshop? 
-> 
+> Take a moment to silently imagine a learner who might attend your workshop. What is their background? What problem do they face?
+> What will they gain from attending your workshop?
+>
 > This exercise should take about 2 minutes.  
 {: .challenge}
 
-As you strive to anticipate your audience, it is 
+As you strive to anticipate your audience, it is
 useful to recognize that you will never know everything about the whole people who come into your classroom. You will not
 be informed about their hopes and fears beyond what they choose to present. You will never know the full spectrum of neurodiversity represented in your
-workshop. You will not know who is going through a rough break-up, who struggles with an abusive work environment, who has a sick baby at home, or who skipped 
-breakfast to save money that morning. What challenges might affect your imaginary person? Thinking deeply about learners as people can help you prepare to bring your 
+workshop. You will not know who is going through a rough break-up, who struggles with an abusive work environment, who has a sick baby at home, or who skipped
+breakfast to save money that morning. What challenges might affect your imaginary person? Thinking deeply about learners as people can help you prepare to bring your
 best self and provide an inclusive environment for everyone.
 
 ### Remember Your Pre-Workshop Surveys
-The Carpentries strives to create useful assessment instruments that can help you plan and understand your workshop. Pre-survey data will likely accumulate 
-right up to the start of your workshop. Be sure to check the links sent by The Carpentries Workshop Administration Team for the most up-to-date information 
+The Carpentries strives to create useful assessment instruments that can help you plan and understand your workshop. Pre-survey data will likely accumulate
+right up to the start of your workshop. Be sure to check the links sent by The Carpentries Workshop Administration Team for the most up-to-date information
 about your trainees. If you think our surveys could benefit from new or different questions, please let us know!
 
 
 ## Examine Learning Objectives
 All Carpentries lessons should have learning objectives listed at the top of each episode. Did you notice these
-in your lesson? In the most 
+in your lesson? In the most
 cases they are quite specific about **what a learner should be able to do** by the end of the episode.
-This is helpful in both designing extra formative assessments and in evaluating possible additions or digressions for 
+This is helpful in both designing extra formative assessments and in evaluating possible additions or digressions for
 appropriateness.
 
-Carpentries learning objectives should target novice learners. This typically means that the actions specified by the learning objective should be 
-basic and uncomplicated. These might include words like "recognize," "distinguish," or "use." They typically do not include words like "design," "evaluate," or "break down" 
-because these imply more complex cognitive actions even where the focal content is the same. 
+Carpentries learning objectives should target novice learners. This typically means that the actions specified by the learning objective should be
+basic and uncomplicated. These might include words like "recognize," "distinguish," or "use." They typically do not include words like "design," "evaluate," or "break down"
+because these imply more complex cognitive actions even where the focal content is the same.
 
 > ## Evaluate Learning Objectives
 >
@@ -95,35 +95,35 @@ because these imply more complex cognitive actions even where the focal content 
 > This exercise should take about 10 minutes.  
 {: .challenge}
 
-Some answers above may include words like "know" and "understand." Surely this is the objective of all teaching! However, 
-these terms are quite difficult to use when it comes time to *assess* whether a learner has met 
-that objective. They are also quite ambiguous with regard to the *level* of understanding to be achieved. Where you encounter these, 
+Some answers above may include words like "know" and "understand." Surely this is the objective of all teaching! However,
+these terms are quite difficult to use when it comes time to *assess* whether a learner has met
+that objective. They are also quite ambiguous with regard to the *level* of understanding to be achieved. Where you encounter these,
 consider how they may be improved by making them specific to an outcome that is clearly achievable and readily assessed.
 
 ### Beware the Urge to Complicate
-When experts teach, they are often eager to advance their learners to higher cognitive levels where challenges seem more interesting or valuable. 
-If the learning objectives in your lesson seem a bit dull, you can understand the appeal! And the goal is laudable. However, teaching is an incremental process, 
+When experts teach, they are often eager to advance their learners to higher cognitive levels where challenges seem more interesting or valuable.
+If the learning objectives in your lesson seem a bit dull, you can understand the appeal! And the goal is laudable. However, teaching is an incremental process,
 and giving in to this urge can result in skipping steps (see "expert awareness gap" in previous episodes), leaving novice learners in a state of cognitive overload.  
-'Higher order' tasks like synthesis or creation rely on more fundamental levels of understanding, and are therefore prone to failure when applied too soon. 
-Awareness of exactly what underlying knowledge is required at each step will help you to avoid asking too much. For more guidance on identifying the "level" of 
+'Higher order' tasks like synthesis or creation rely on more fundamental levels of understanding, and are therefore prone to failure when applied too soon.
+Awareness of exactly what underlying knowledge is required at each step will help you to avoid asking too much. For more guidance on identifying the "level" of
 a particular task, we recommend having a look at one of many excellent references on Bloom's Taxonomy.
 
 
 ## Prepare to Use Formative Assessments
 When a learning objective has been met, everyone should know about it! You, as an Instructor, can be satisfied that your teaching has successfully translated
-into learning. For learners, recognizing that they have successfully learned something is motivating and it also supports their ability to monitor their own 
-progress -- this awareness, or **metacognition**, is especially key to supporting continued learning beyond the classroom. However, not all lessons have 
+into learning. For learners, recognizing that they have successfully learned something is motivating and it also supports their ability to monitor their own
+progress -- this awareness, or **metacognition**, is especially key to supporting continued learning beyond the classroom. However, not all lessons have
 checkpoints built in where such progress is made clear. Where they do, they can pass unnoticed in the absence of focused recognition.
 
 > ## Where are your Checkpoints?
 >
 > Have a look at your learning objective again and identify
-> *where* in the lesson that objective should reasonably be achieved. 
+> *where* in the lesson that objective should reasonably be achieved.
 >
 > This exercise should take about 5 minutes.
 {: .challenge}
 
-Now that you have identified one point where formative assessment may be useful, take a moment to consider how it might be used most 
+Now that you have identified one point where formative assessment may be useful, take a moment to consider how it might be used most
 effectively.
 
 > ## Assessment is for Everyone
@@ -159,32 +159,32 @@ in which you were going to explain something that your learners already know.
 > the less people know about a subject,
 > the less accurate their estimate of their knowledge is. Therefore, if you ask a room full of people
 > "Do you understand?" the result will invariably be a number of 'yes' responses (many of them inaccurate) which tend to drown out a
-> variable amount of silence. Instead, a targeted formative assessment takes the inaccuracy and stress of self-judgement away and 
+> variable amount of silence. Instead, a targeted formative assessment takes the inaccuracy and stress of self-judgement away and
 > demonstrates to all whether the learners' level of understanding has
 > met the instructor's goal.
 {: .callout}
 
 
 ## Prepare to Cut
-Collaborative maintenance of curriculum materials allows The Carpentries to maintain up-to-date workshops in a rapidly changing world. 
-We hope you will join in to support our Maintainers in overseeing this process, and even consider becoming a curriculum Maintainer yourself! 
-However, there is one down-side to collaborative upkeep: adding content is a much more fun way to contribute than proposing content to remove. 
+Collaborative maintenance of curriculum materials allows The Carpentries to maintain up-to-date workshops in a rapidly changing world.
+We hope you will join in to support our Maintainers in overseeing this process, and even consider becoming a curriculum Maintainer yourself!
+However, there is one down-side to collaborative upkeep: adding content is a much more fun way to contribute than proposing content to remove.
 Every workshop moves at its own pace, but if you are following our recommendations to **go slowly** and pause for formative assessment, it is likely
-that you will have to make cuts in what you plan to teach. Indeed, despite our best efforts at maintaining this curriculum, your Instructor Trainers 
-may well have had to make cuts to make space for great conversations or extra questions in this training! 
+that you will have to make cuts in what you plan to teach. Indeed, despite our best efforts at maintaining this curriculum, your Instructor Trainers
+may well have had to make cuts to make space for great conversations or extra questions in this training!
 
-There are many ways to make cuts in a workshop, and they can have variable knock-on effects to watch out for. A little advance planning goes a long way 
+There are many ways to make cuts in a workshop, and they can have variable knock-on effects to watch out for. A little advance planning goes a long way
 to avoid making mistakes when you start cutting things 'on the fly.'
-- **Keep breaks on time** even if your content is split awkwardly around them. Delaying breaks can demotivate your audience and disrupt plans they may 
+- **Keep breaks on time** even if your content is split awkwardly around them. Delaying breaks can demotivate your audience and disrupt plans they may
 make around announced break times.
-- **Watch out for dependencies** if you skip a step. It may not be a step they *needed to know* about, but it may generate or re-name a file that is used 
+- **Watch out for dependencies** if you skip a step. It may not be a step they *needed to know* about, but it may generate or re-name a file that is used
 in later episodes.
 - **Leave time to wrap up your workshop** even if this means cutting even more content. We will talk about this more shortly.
-- **Do not speed up** if you are running behind! All curricula are freely available so learners can visit content they have missed; this means there is very 
+- **Do not speed up** if you are running behind! All curricula are freely available so learners can visit content they have missed; this means there is very
 little to be gained by "quickly covering" (but not actually teaching) content.
-- **Communicate with your team** about what you plan to cut, or what you decided to leave out. Do not assume anyone will notice if you skip something. They may be 
+- **Communicate with your team** about what you plan to cut, or what you decided to leave out. Do not assume anyone will notice if you skip something. They may be
 able to find a way to fit certain concepts in with later content if they know it has been missed.
-- **Communicate with your learners** about where they can find skipped content and whether any help may be available to support their independent work. Cutting 
+- **Communicate with your learners** about where they can find skipped content and whether any help may be available to support their independent work. Cutting
 content may make them feel anxious, but it will help for them to know how to follow up.
 
 
@@ -195,17 +195,17 @@ from instructors who have already taught the material. This can be a valuable
 resource when preparing lessons, especially when teaching a lesson for the first time.  
 The instructor notes are linked on each lesson page under the "Extras" pull down menu.
 In addition, configuration problems and other
-technical hurdles common across multiple lessons are detailed [in this community-developed page][Config] 
-along with suggested solutions. This link is built into each workshop website as well for easy access by learners and 
-during workshops. When you find new problems or solutions, please contribute! 
+technical hurdles common across multiple lessons are detailed [in this community-developed page][Config]
+along with suggested solutions. This link is built into each workshop website as well for easy access by learners and
+during workshops. When you find new problems or solutions, please contribute!
 
 
 ## Review Prior Feedback
-When is the best time to review your post-workshop survey responses and other feedback that you received during a workshop? We certainly recommend 
-taking time to do this after a workshop, while your memories are still fresh. However, we *also* recommend having a look again **before you teach your 
-next workshop**. This will help refresh your memory of all that went well (yay!) as well as challenges you faced and learners who struggled at certain points. 
-What will you keep the same, and what will you do differently? 
-Just a few moments of reflective practice with prior feedback will go a long way towards building your skill as a teacher and making each workshop you teach 
+When is the best time to review your post-workshop survey responses and other feedback that you received during a workshop? We certainly recommend
+taking time to do this after a workshop, while your memories are still fresh. However, we *also* recommend having a look again **before you teach your
+next workshop**. This will help refresh your memory of all that went well (yay!) as well as challenges you faced and learners who struggled at certain points.
+What will you keep the same, and what will you do differently?
+Just a few moments of reflective practice with prior feedback will go a long way towards building your skill as a teacher and making each workshop you teach
 better than the last.
 
 
@@ -225,19 +225,18 @@ better than the last.
 
 
 ## Connect With Your Team
-Are you teaching with some of the same team-members you taught with previously? If so, this is a great time for *collaborative* feedback review! Depending on 
-your team's preferences, many of the independent preparation steps described here can be carried out collaboratively or at least in good company. In addition, 
+Are you teaching with some of the same team-members you taught with previously? If so, this is a great time for *collaborative* feedback review! Depending on
+your team's preferences, many of the independent preparation steps described here can be carried out collaboratively or at least in good company. In addition,
 we will talk about how to prepare with your team to create a cohesive classroom experience in a later episode.
 
 
 > ## Minute Cards Revisited
 >
 > Use your sticky notes to write minute cards
-> as discussed [yesterday]({{ page.root }}/{% link _episodes/06-feedback.md %}#minute-cards).
+> as discussed [in part 1]({{ page.root }}/{% link _episodes/06-feedback.md %}#minute-cards).
 {: .challenge}
 
 
 [Wiggins]: https://www.worldcat.org/title/understanding-by-design/oclc/56491025
 [Config]: https://github.com/carpentries/workshop-template/wiki/Configuration-Problems-and-Solutions
 [Dunning]: https://en.wikipedia.org/wiki/Dunning%E2%80%93Kruger_effect
-

--- a/_episodes/19-lunch.md
+++ b/_episodes/19-lunch.md
@@ -1,6 +1,6 @@
 ---
 layout: break
-title: "End Third Half Day"
+title: "End Part 3"
 teaching: 0
 exercises: 0
 break: 60

--- a/_episodes/22-coffee.md
+++ b/_episodes/22-coffee.md
@@ -1,6 +1,6 @@
 ---
 layout: break
-title: "Afternoon Break"
+title: "Part 4 Break"
 teaching: 0
 exercises: 0
 break: 15

--- a/_episodes/23-introductions.md
+++ b/_episodes/23-introductions.md
@@ -14,19 +14,19 @@ keypoints:
 - "Conclusions support reflective practice and set the stage for continued learning."
 ---
 
-When preparing to teach a workshop, it is normal to focus on the content. We hope that our discussions so far have also encouraged you to prepare your delivery, 
+When preparing to teach a workshop, it is normal to focus on the content. We hope that our discussions so far have also encouraged you to prepare your delivery,
 creating plans to listen and respond to learners during a workshop. But within that, there are two time points that make a big difference to a
-workshop experience: the introduction and the conclusion. Because these take time away from content instruction, it can be tempting to avoid investing precious 
-preparation and class time to these sections. However, a strong introduction sets the tone for your workshop, teaches learners how to engage, and inspires 
+workshop experience: the introduction and the conclusion. Because these take time away from content instruction, it can be tempting to avoid investing precious
+preparation and class time to these sections. However, a strong introduction sets the tone for your workshop, teaches learners how to engage, and inspires
 confidence that learners will get what they need. A solid conclusion helps learners to solidify what they have learned and plan their next steps, and sends the
-everyone -- including Instructors and Helpers -- home with a sense of accomplishment. In this section, we will work together to identify ingredients that can 
-make these moments stand out and dedicate some practice time as well. 
+everyone -- including Instructors and Helpers -- home with a sense of accomplishment. In this section, we will work together to identify ingredients that can
+make these moments stand out and dedicate some practice time as well.
 
 ## Launching your Workshop: The Introduction
 Take a moment to think back to a course or workshop you really liked, think about how it began. Your impression on the first day of a course probably matched that of the rest of the course. It also probably stands out in your memory far more than the rest of the course! This is due to a feature of memory known as the **primacy effect**.
 Opening experiences make a difference in the short and long term -- introductions set the tone for the workshop and the path for learning.
 
-Introducing a workshop is an exciting and empowering moment! It can also be intimidating. Having a plan helps relieve stress and get you started. 
+Introducing a workshop is an exciting and empowering moment! It can also be intimidating. Having a plan helps relieve stress and get you started.
 Even in the face of
 early technical issues  (which is common at the start of a workshop), you can have a chance to reset with something
 you are comfortable and ready for.
@@ -51,7 +51,7 @@ you are comfortable and ready for.
 >> 1.  Set the tone for the workshop
 >> 1.  Collect baseline data on learners' knowledge and motivation
 >> 1.  Whet learners' appetite for workshop content
->> 1.  Inform Learners of Logistics 
+>> 1.  Inform Learners of Logistics
 > {: .solution}
 {: .challenge}
 
@@ -60,7 +60,7 @@ you are comfortable and ready for.
 It can feel like the Introduction is "just" something you have to get through in order to get started on the "real" workshop content.
 But, chances are that many of the goals you identified in the activity above involved *teaching* information or procedures that
 you want learners to know, or *learning* things about your audience. This means that everything you have learned about
-teaching and learning applies here, too. Short term memory? Check! Cognitive overload? Check! 
+teaching and learning applies here, too. Short term memory? Check! Cognitive overload? Check!
 
 Learning objectives usually omit introductory content -- after all, these do not typically relate to our long term goals. The content of the introduction may not even be relevant once the workshop has
 finished! But if we did include the Introduction, what would those learning objectives look like?
@@ -79,11 +79,11 @@ The instructional team should:
 
 ### Setting the Stage
 
-These objectives can be met in many ways; many of them can be addressed at the same time. As you consider the approach you will take, 
-take a step back to consider the big picture. How will learners perceive your classroom environment? A few things to pay attention to 
-as you include: 
+These objectives can be met in many ways; many of them can be addressed at the same time. As you consider the approach you will take,
+take a step back to consider the big picture. How will learners perceive your classroom environment? A few things to pay attention to
+as you include:
 
-**Your attire.** This is one of those things that "should not matter" but, in reality, clothing has a powerful influence on perceptions of everything from 
+**Your attire.** This is one of those things that "should not matter" but, in reality, clothing has a powerful influence on perceptions of everything from
 credibility to kindness. Be comfortable, be intentional, and convey what you want to communicate. (Also, check the weather, and make
 no assumptions about thermostats in an unfamiliar classroom!)
 
@@ -96,7 +96,7 @@ no assumptions about thermostats in an unfamiliar classroom!)
 * how formal/informal you want to be
 * how available you will be to the learners
 * your enthusiasm for the subject
-* your motivations for teaching 
+* your motivations for teaching
 
 > ## Introductions for Everyone
 >
@@ -109,12 +109,12 @@ no assumptions about thermostats in an unfamiliar classroom!)
 >
 {: .callout}
 
-**Your doubts.** Sometimes if you have doubts about how the workshop will go, either because you are new to teaching or because you are aware of potential 
-problems, this may come across (intentionally or unintentionally) during your introduction. Sharing such vulnerabilities judiciously can help keep learners on 
+**Your doubts.** Sometimes if you have doubts about how the workshop will go, either because you are new to teaching or because you are aware of potential
+problems, this may come across (intentionally or unintentionally) during your introduction. Sharing such vulnerabilities judiciously can help keep learners on
 your side when problems do arise. However, there is also a risk of undermining learner confidence. Thinking this through in advance can keep you from oversharing
 in a moment of anxiety!
 
-**The classroom community.** Becoming familiar with other participants helps learners relax and engage, breaking down fear and supporting a sense of belonging. 
+**The classroom community.** Becoming familiar with other participants helps learners relax and engage, breaking down fear and supporting a sense of belonging.
 Icebreakers can seem silly and they do take time, but even a lightweight activity makes a big difference. This also sets the tone for an active workshop, which
 can be especially important if your curriculum does not offer early opportunities for interaction.
 
@@ -136,11 +136,11 @@ This information should also be present in your workshop documentation and/or co
 
 **Describe the prerequisites** (if any).
 
-**Share the schedule and logistics.** Post lunch and break times, and stick to them! Share bathroom & lactation room locations and any other 
-instructions specific to your workshop. Demonstrating a commitment to accessibility at this point will help learners feel more comfortable making 
+**Share the schedule and logistics.** Post lunch and break times, and stick to them! Share bathroom & lactation room locations and any other
+instructions specific to your workshop. Demonstrating a commitment to accessibility at this point will help learners feel more comfortable making
 additional requests as needed.
 
-**Communicate the workshop structure**, including learning objectives and hands-on approach. If your instructional team has distinct roles in the workshop (e.g. 
+**Communicate the workshop structure**, including learning objectives and hands-on approach. If your instructional team has distinct roles in the workshop (e.g.
 "notetaker" vs "roaming helper", be sure to introduce them, too.
 
 **Communicate your expectations** for learners, including:
@@ -148,21 +148,21 @@ additional requests as needed.
 - ways to ask for help
 - ways to give feedback to the instructional team
 
-**Collect and share baseline data on learners**. If you are teaching an official Carpentries workshop, you should have received the results of your pre-assessment surveys 
--- these can be helpful in planning your workshop! Even so, you may have additional questions, and there will always be learners who did not fill out the survey. 
+**Collect and share baseline data on learners**. If you are teaching an official Carpentries workshop, you should have received the results of your pre-assessment surveys
+-- these can be helpful in planning your workshop! Even so, you may have additional questions, and there will always be learners who did not fill out the survey.
 Sharing and discussing these data with learners can help to combat imposter syndrome and let them know that they are welcome 'as they are'.
 
-**Share some advice for success** -- including your confidence that they can do it! If you have a range of skill backgrounds, this is a good opportunity to offer 
+**Share some advice for success** -- including your confidence that they can do it! If you have a range of skill backgrounds, this is a good opportunity to offer
 differentiated advice on how to make the most of the experience, e.g. suggesting that intermediate learners build their skills by helping a neighbour or
 considering more advanced questions to be discussed during the breaks.
 
-**Whet learners' appetites for workshop content**. In most cases, your learners chose to attend this workshop, but they may yet be unclear on whether it will 
+**Whet learners' appetites for workshop content**. In most cases, your learners chose to attend this workshop, but they may yet be unclear on whether it will
 be worthwhile. This is a great chance to get them excited about the prospect of learning what you have to teach!
 
 
 > ## Practice Your Introduction
 >
-> Imagine you have completed instructor training and you are about to teach a full lesson around the material you have been practicing teaching today.
+> Imagine you have completed instructor training and you are about to teach a full lesson around the material you have been practicing teaching during this training.
 >
 > 1. Write out some notes, covering a few of the topics described above:
 > 	1.  Introduce yourself effectively
@@ -176,26 +176,26 @@ be worthwhile. This is a great chance to get them excited about the prospect of 
 
 ## The Art of a Smooth Landing
 Your workshop almost certainly had some highs and lows. If you followed our advice about going slowly, it is also likely that you will be pressed for time
-at the end! Out of respect for all involved, it is important that you end your workshop on time. Even if you have not met your content goals, 
+at the end! Out of respect for all involved, it is important that you end your workshop on time. Even if you have not met your content goals,
 there are far more valuable ways to spend the last 15-20 minutes of a course than squeezing in one last command or bit of advice.
 
 > ## Brainstorm: Making the Last Moments Count
 >
 > You have made it to the end of your workshop! Everyone is exhausted and their brains are full. You could cover more content... or you could use the last few
-> minutes in another way. 
+> minutes in another way.
 >
-> In the Etherpad, write down one thing you could do at the end of a workshop. What is the value of spending time on that thing? 
-> If you have time after writing down your idea, read through the others in the Etherpad. If you have another idea that has not been written down yet, add it 
+> In the Etherpad, write down one thing you could do at the end of a workshop. What is the value of spending time on that thing?
+> If you have time after writing down your idea, read through the others in the Etherpad. If you have another idea that has not been written down yet, add it
 > to the list.
 >
 > This exercise will take about 5 minutes.
 > > ## Solution
 > > - Close and save files. Where can those files be found, and how can learners pick up independently where you left off?
 > > - Reflect on learning. This can help learners to solidify key concepts they have learned, making them easier to remember. It may also flush out a few last questions.
-> > - Plan next steps. Does the local community have resources to support continued learning? 
+> > - Plan next steps. Does the local community have resources to support continued learning?
 > > Do you have advice for how learners might continue on their own? Even
 > > if you have no advice, asking learners to take a moment to discuss their own plans can support them in taking a next step sooner rather than later.
-> > - Collect feedback. Minute cards, one-up-one-down, and making time for Carpentries post-assessment surveys will support your continuing development as an 
+> > - Collect feedback. Minute cards, one-up-one-down, and making time for Carpentries post-assessment surveys will support your continuing development as an
 > > Instructor as well as our continuing development of Carpentries programs. This can also support or complement a reflection activity.
 > > - Check with the workshop host to see if they have any closing words or instructions they would like to share.
 > > - Celebrate everyone's hard work. Thank your learners for helping each other, for staying motivated and persevering with you! Thank your helpers -- keep a

--- a/_extras/additional_exercises.md
+++ b/_extras/additional_exercises.md
@@ -7,11 +7,11 @@ title: "Additional Exercises"
 > ## Modeling Novice Mental Models
 >
 > Create a multiple choice question related to a lesson you intend to teach.
-> 1. Think about the topic of the lesson. What relevant misconceptions might a novice learner bring to the classroom? 
+> 1. Think about the topic of the lesson. What relevant misconceptions might a novice learner bring to the classroom?
 > 2. Create your question. How many choices can you think of that will diagnose a specific misconception?
 > 3. Type your question into the Etherpad
 > and **explain the diagnostic power of each choice.**
-> 
+>
 > This exercise should take about 10 minutes.
 {: .challenge}
 
@@ -47,7 +47,7 @@ title: "Additional Exercises"
 
 ## Episode 9: Equity, Inclusion, and Accessibility
 
- 
+
 > ## Learning about Accessibility
 >
 > The [UK Home Office](https://hodigital.blog.gov.uk/category/accessibility/) has put together a
@@ -56,10 +56,10 @@ title: "Additional Exercises"
 > [these posters](https://ukhomeoffice.github.io/accessibility-posters/posters/accessibility-posters.pdf) and put one thing you
 > have learned in the Etherpad.
 >
-> Note: There is an [HTML version](https://ukhomeoffice.github.io/accessibility-posters/) in English which may perform better 
+> Note: There is an [HTML version](https://ukhomeoffice.github.io/accessibility-posters/) in English which may perform better
 > with screen readers. There are also [translations](https://github.com/UKHomeOffice/posters/tree/master/accessibility/dos-donts)
 > available in a number of languages, including Dutch, French, Spanish, Swedish, Portuguese, German, and
-> Chinese. 
+> Chinese.
 >
 > This exercise should take about 5 minutes.
 {: .challenge}
@@ -85,7 +85,7 @@ title: "Additional Exercises"
 
 ## Episode 15: Preparing to Teach
 
-For our next exercise, we will explore some deep thinking about the 'whole people' who might come to your classroom by creatively brainstorming a **learner 
+For our next exercise, we will explore some deep thinking about the 'whole people' who might come to your classroom by creatively brainstorming a **learner
 profile**. This is a good way to support an empathic and intentional approach to your plan for instruction.
 
 Learner profiles have three parts:
@@ -126,7 +126,7 @@ Learner profiles have three parts:
 > ## Feedback On Your Challenges (Optional)
 >
 > With these goals in mind, pair up with a partner to discuss the MCQ and faded example problems that you wrote
-> yesterday. Give each other specific, actionable feedback that follows our 2x2 framework. Use that feedback to
+> in part 1. Give each other specific, actionable feedback that follows our 2x2 framework. Use that feedback to
 > make at least one modification to your exercise(s). Discuss in the Etherpad the change you made and how it will
 > help you get more useful information about your learners.
 >

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -25,12 +25,12 @@ Details about the Instructor Trainer role including the application process, dut
 ### Four Weeks before the Event
 -  Contact your co-Trainer(s) to plan how you will co-teach.  Suggested discussion questions include:
     - What are some useful tips and tricks to organize yourself, pace yourself, share resources, etc. while teaching?
-    - How do you ensure that all trainees stay engaged and participate? 
+    - How do you ensure that all trainees stay engaged and participate?
     - How can Trainers help each other (at times when we are not the active Trainer)? How should we communicate with each other during the training?
     - How can we address trainee challenges? These may include internet connectivity problems, distractions caused by working from home, etc.
 -  Create an event Etherpad (using the [Etherpad template][etherpad-template]) or Google Doc (there is now a [template](https://docs.google.com/document/d/1P_w1rgdVk4SpXvILSS-ZKz8Ujqklfujpc_zHf8D-G1A/edit?usp=sharing) for that, too) and a workshop website (using the [training template][training-template]). *Be sure to check the event Etherpad or Google Doc against the curriculum as you prepare to teach, as these may not be reliably updated with curriculum changes.*
 -  Send Etherpad/Google Doc and website links to training@carpentries.org.  
--  Consider forking the Instructor Training curriculum and doing all of your preparation work based on your fork so that any changes do not impact your preparation. 
+-  Consider forking the Instructor Training curriculum and doing all of your preparation work based on your fork so that any changes do not impact your preparation.
 
 ### One Week before the Event    
 -  Plan logistics with co-Trainer(s)
@@ -78,11 +78,11 @@ you risk losing the audience's attention because your face is less prominent.
 If you chose to use slides in your workshop,
 this [Google Drive folder][slides-folder] contains slides with diagrams, cartoons, and text that trainers have used past workshops. Feel free to reuse the existing materials or add your own slides.
 
-### Using Etherpad 
+### Using Etherpad
 
-Each workshop will have an Etherpad. 
+Each workshop will have an Etherpad.
 You can use the [Instructor Training Etherpad template](https://pad.carpentries.org/ttt-template)
-to quickly copy and paste challenges or useful information into your Etherpad. 
+to quickly copy and paste challenges or useful information into your Etherpad.
 
 Given the central role that Etherpad plays is running Carpentry workshops,
 you may want to take a minute to explain [how to create a pad](https://pad.carpentries.org/),
@@ -107,11 +107,11 @@ here are some ways where it is easy to do so without much prep:
 
 ### Episode order
 
-Experience has shown that the current order of episodes works quite well. 
-If you are a new Trainer, we recommend following the official order, however, 
-the material is flexible enough to allow small shifts in episode order. 
-If you are an experienced Trainer and you would like to re-arrange the schedule, 
-make sure to communicate with your trainees and co-Trainers! 
+Experience has shown that the current order of episodes works quite well.
+If you are a new Trainer, we recommend following the official order, however,
+the material is flexible enough to allow small shifts in episode order.
+If you are an experienced Trainer and you would like to re-arrange the schedule,
+make sure to communicate with your trainees and co-Trainers!
 
 ## III. Online vs In Person Training Events
 
@@ -147,10 +147,10 @@ account for yourself for free. This personal account will be able to attend the 
 
 ### Becoming the meeting host
 
-About a week before your event, you will be given login credentials for a Carpentry account. Alternatively, if no 
-one has yet claimed "host" in your session, you can click "claim host" next to your name in the Participants list; 
+About a week before your event, you will be given login credentials for a Carpentry account. Alternatively, if no
+one has yet claimed "host" in your session, you can click "claim host" next to your name in the Participants list;
 you will be asked for a 6-digit host key, which you can find [in this message](https://carpentries.topicbox.com/groups/trainers/T3ec157cc9a3d1833/zoom-host-code).
-See [the explanation here][zoom-host-key] for step-by-step instructions on how to 
+See [the explanation here][zoom-host-key] for step-by-step instructions on how to
 claim host in Zoom Rooms using the host key.
 
 This account will be the host for the event and will have extra privileges including the
@@ -205,7 +205,7 @@ you’re not the host, please contact Carpentry staff immediately.
   - During breaks, learners will often turn off their video and wait for your audio cue to re-activate. This makes it look like no one is back from break, but just saying 'hello' will generally get a bunch of people to come back on video quickly.
   - When several attendees are in the same room (member trainings): it is helpful to have every participant log in separately so that you can see names and faces and they can interact by waving or using the chat. However, it is important that only one microphone and speaker should be active in the room at one time or feedback and noise will be a problem. When creating breakouts, you can either leave these people in the main room or shuffle people around to create a room just for them. Either way, ask them to leave a mic on so you can listen in.
   - Attendees might like to have a separate room (without Trainers) to network in over lunch or other breaks. Be prepared to assign that room and then close it to restart the main session.
-  - You can never practice too much with Zoom! 
+  - You can never practice too much with Zoom!
 
 ## V. Curriculum Teaching Tips
 
@@ -249,7 +249,7 @@ As written, this can run long.  Suggestions:
 
 ### Mindset
 ### Teaching is a Skill
-### Wrap-Up and Homework for Tomorrow
+### Wrap-Up and Homework
 
 ### Welcome Back
 ### Live Coding	is a Skill
@@ -289,27 +289,27 @@ group is interested.
 This section contains tips and tricks on demo hosting that may be contributed by any Trainer describing things that work for them. For official/technical guidelines on how to run a demo, see the [Handbook](https://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html#running-a-teaching-demonstration).
 
 Suggested points to make during introductions:
-* This is not a high-stakes test! This is a friendly opportunity to give and receive feedback. On occasion, we do invite 
+* This is not a high-stakes test! This is a friendly opportunity to give and receive feedback. On occasion, we do invite
 people to return for a second try. If we do this, your follow-up email will contain very clear instructions on exactly what
 we would like you to change on your next visit. This does not mean we do not want you as an instructor, it means we want you to be
 ready to put your best foot forward in the classroom and we are here to help you do that. (KW)
 * I will not tell anyone that they have passed or ask anyone to repeat during this session. That information will come in the follow up email. (KW)
 * The feedback you give sometimes says as much or more about your approach to instruction as the demo itself. (KW)
-* Have trainees introduce themselves (name and institution or location) at the start. This makes sure everyone knows where the 
+* Have trainees introduce themselves (name and institution or location) at the start. This makes sure everyone knows where the
 mute button is. (EB)
 * I have already determined a random order for you each to do your demonstration. When it is your turn, I will tell you what
 episode you will be teaching from, and
-you will have a minute or two to set up your screen. You will screen share (describe where the button is) and will have the 
+you will have a minute or two to set up your screen. You will screen share (describe where the button is) and will have the
 option to share your whole Desktop or just a single application. I recommend sharing only the application you will be teaching
 from, that way you can keep your notes up on your screen without us seeing them. It is perfectly fine to teach using your
 notes - that is how I always teach. (EB)
 * When your time is up, I will stop you and ask you to give feedback on yourself and then ask others to add their feedback. (EB)
 
 Different ways of managing feedback during the demo:
-* Create your own Etherpad and populate it with episode links, feedback templates, whatever. 
+* Create your own Etherpad and populate it with episode links, feedback templates, whatever.
 * Use +/- content delivery rubric. (Or use "improvement" in place of "-" as suggested by MC). Keep in mind that some learners
 (like some Trainers) do not have the content expertise to be able to fully evaluate that category for all lessons.
-* If there is time (4 people or less) you can do feedback entirely verbally, or have them issue verbal feedback after writing 
+* If there is time (4 people or less) you can do feedback entirely verbally, or have them issue verbal feedback after writing
 notes in the Etherpad. If you do this, suggest having presenter give their own feedback, then other learners, then Trainer can
 summarize/disagree/add/emphasize as needed.
 * I take notes on physical paper during each demo with points I think need to be made, then mark things off as others


### PR DESCRIPTION
closes #1385 

I did not change episode names to remove "lunch" to avoid breaking links, but maybe we can do that too? but I think I got all of the other temporal references changed to parts instead of two days. 