### PR TITLE
Fix broken code of conduct links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,6 @@ training_site: "https://carpentries.github.io/instructor-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"
 workshop_site: "https://carpentries.github.io/workshop-template"
 cc_by_human: "https://creativecommons.org/licenses/by/4.0/"
-coc: "https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html"
 
 # Surveys.
 instructor_pre_survey: "https://carpentries.typeform.com/to/QVOarK#slug="

--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,7 @@ training_site: "https://carpentries.github.io/instructor-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"
 workshop_site: "https://carpentries.github.io/workshop-template"
 cc_by_human: "https://creativecommons.org/licenses/by/4.0/"
+coc: "https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html"
 
 # Surveys.
 instructor_pre_survey: "https://carpentries.typeform.com/to/QVOarK#slug="

--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -155,7 +155,7 @@ We will have many opportunities to practice and give each other feedback through
 ### Creating a Positive Learning Environment
 
 One part of making this a productive experience for all of us is a
-community effort to treat one another with kindness and respect.  The [Code of Conduct]({{ site.coc }}) 
+community effort to treat one another with kindness and respect.  The [Code of Conduct][coc] 
 is one piece of this. We will also be discussing and practicing teaching techniques to create a positive and
 welcoming environment in your classrooms, and will spend some time talking about why this is important.
 

--- a/_episodes/09-eia.md
+++ b/_episodes/09-eia.md
@@ -250,10 +250,10 @@ groups in your community who may be interested in attending.
 ### Setting Expectations with the Code of Conduct
 
 One central way that The Carpentries fosters an inclusive, respectful
-learning environment is our [Code of Conduct]({{ site.coc }}).
+learning environment is our [Code of Conduct][coc].
 
 All participants in our workshops and communities are required to abide by the
-[Code of Conduct]({{ site.coc }}).
+[Code of Conduct][coc].
 This code helps to ensure that our community does not tolerate the persistence of behaviors 
 that harm or exclude others. While such a code cannot prevent all incidents, reminding 
 participants of the Code of Conduct supports them in 

--- a/_episodes/09-eia.md
+++ b/_episodes/09-eia.md
@@ -301,6 +301,7 @@ at the top), though our [#accessibility channel][slack-accessibility] on [The Ca
 
 [34gig]: https://ijoc.org/index.php/ijoc/article/view/1566
 [glossary]: https://www.diversity.pitt.edu/education/diversity-equity-and-inclusion-glossary
+[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
 [core-values]: https://carpentries.org/values/
 [CAST]: https://udlguidelines.cast.org
 [handbook-accessibility-checklist]: https://docs.carpentries.org/topic_folders/hosts_instructors/workshop_needs.html#accessibility


### PR DESCRIPTION
Looks like this was removed in an earlier commit, but it's still used in lesson plans.