### PR TITLE
Rename 'up and down' exercise

### DIFF
--- a/_episodes/17-live.md
+++ b/_episodes/17-live.md
@@ -37,7 +37,7 @@ Importantly, learners are strongly encouraged
 to "code-along" with the instructor.
 We refer to the practice of having the instructor live code and the learners code along as "participatory live coding" or, less formally, 'code-along sessions'.
 
-> ## Up and Down
+> ## Anticipate the Pros and Cons
 >
 > List some advantages and challenges of participatory live coding
 > from both a learner's and an instructor's point of view

--- a/_episodes/17-live.md
+++ b/_episodes/17-live.md
@@ -37,7 +37,7 @@ Importantly, learners are strongly encouraged
 to "code-along" with the instructor.
 We refer to the practice of having the instructor live code and the learners code along as "participatory live coding" or, less formally, 'code-along sessions'.
 
-> ## Anticipate the Pros and Cons
+> ## Anticipate the Impact
 >
 > List some advantages and challenges of participatory live coding
 > from both a learner's and an instructor's point of view


### PR DESCRIPTION
Suggested update to address #1419 

Could be a little long for an exercise title, but I included 'anticipate' as a way to reinforce the importance of reflection as assessment. Feel free to shorten!