### PR TITLE
fix mistaken indent in list

### DIFF
--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -136,10 +136,10 @@ The mental model of an expert in any given subject will be far larger and more c
 and more detailed and numerous relationships. However, **both may be perfectly useful** in certain contexts. 
 
 Returning to our example levels of skill development: 
-*     A *novice* has a minimal mental model of surface features of the domain. Inaccuracies based on limited prior knowledge may interfere with adding new information.
+* A *novice* has a minimal mental model of surface features of the domain. Inaccuracies based on limited prior knowledge may interfere with adding new information.
 Predictions are likely to borrow heavily from mental models of other domains
 which seem superficially similar.
-*     A *competent practitioner* has a mental model that is useful for everyday purposes. Most new information
+* A *competent practitioner* has a mental model that is useful for everyday purposes. Most new information
 they are likely to encounter will fit well with their existing model. Even though many potential elements of their mental model may
 still be missing or wrong, predictions about their area of work are usually accurate.
 * An *expert* has a densely populated and connected mental model that is especially good for problem solving. 


### PR DESCRIPTION
This fixes an issue where a list item, sufficiently indented, becomes a code block in commonmark-descendent markdown parsers (which includes GitHub's markdown and pandoc)

Thanks to @sstevens2 for finding this discrepancy in https://github.com/carpentries/lesson-transition/issues/13