### PR TITLE
README: point maintainer links to their ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ or run `make` in this directory for a list of helpful commands.
 [lesson-example]: https://carpentries.github.io/lesson-example
 [swc-site]: http://software-carpentry.org
 [lc-site]: https://librarycarpentry.org
-[koch_christina]: https://carpentries.org/instructors/
-[brown_sarah]: https://carpentries.org/instructors/ 
-[dennis_tim]: https://carpentries.org/instructors/
-[perez-suarez_david]: https://carpentries.org/instructors/
-[porter-nathaniel]: https://carpentries.org/instructors/
-[wheeler_jon]: https://carpentries.org/instructors/
+[brown_sarah]: https://carpentries.org/instructors/#brownsarahm
+[dennis_tim]: https://carpentries.org/instructors/#jt14den
+[perez-suarez_david]: https://carpentries.org/instructors/#dpshelio
+[porter-nathaniel]: https://carpentries.org/instructors/#ndporter
+[wheeler_jon]: https://carpentries.org/instructors/#jonathanwheeler01
 [word_karen]: https://carpentries.org/team/


### PR DESCRIPTION
The reference links for the maintainers all go to the same place, which is not great for accessibility and can be kind of frustrating when you want to find a specific maintainer and you have to scroll through the same page over and over. 

Since the instructors page has anchors that represent the GitHub IDs for the maintainers, I've added those to the URLs to make them unique. 

This will also help address the transition to The Workbench: https://github.com/fishtree-attempt/instructor-training/issues/11 and https://github.com/carpentries/lesson-transition/issues/15
