### PR TITLE
Update demo etherpad link

### DIFF
--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -250,7 +250,7 @@ work for a checkout demo. Be sure to give yourself time to change course if your
 
 ### Sign-up and Set-up
 
-To sign up, select a session that works for you on [the Instructor Training Demonstration Sessions Etherpad]({{page.demopad}}), and add
+To sign up, select a session that works for you on [the Instructor Training Demonstration Sessions Etherpad](https://pad.carpentries.org/teaching-demos), and add
 your name and a link to your lesson of choice to that Etherpad. Be sure to **double check the time in your local time zone** by clicking on the converter link posted. Also, examine the demo description to ensure that it is not a special session targeting a specific sub-community or
 language (unless you are part of that target group).
 


### PR DESCRIPTION
Replaces no longer working `{{page.demopad}}` link with hardcoded etherpad link. Credit to Clifford Kravit for bringing this to my attention.

Need to verify with @zkamvar prior to merging whether this should be hard-linked or should remain as a page link and corrections made to ensure it works properly again.