### PR TITLE
More links to fix

### DIFF
--- a/episodes/08-motivation.md
+++ b/episodes/08-motivation.md
@@ -176,7 +176,7 @@ This exercise should take about 5 minutes.
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 - **Presenting the instructor as a learner**. We want our learners to have confidence in our qualifications, but it is easy to take this too far. Presenting yourself as a learner offers a relatable model, fostering a growth mindset and teaching a positive approach to the continuing challenge of learning. Using
-  [participatory live coding](17-live/), our chosen method for teaching concepts, is very useful for this reason. It is common to make errors while
+  [participatory live coding](17-live), our chosen method for teaching concepts, is very useful for this reason. It is common to make errors while
   coding. Embrace these with enthusiasm! Leveraging your own mistakes as opportunities can turn an awkward moment into a highlight of a lesson, demonstrating both
   problem-solving approaches and positive error framing. If you are unlucky and fail to make any useful mistakes, sharing stories about your learning process can
   help here, too.

--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -296,7 +296,7 @@ Approximately 1-2 weeks after your last step is complete, you should receive an 
 
 [help-wanted]: https://carpentries.org/help-wanted-issues/
 [github-guide]: https://github.com/carpentries-incubator/swc_github_flow/blob/master/for_novice_contributors.md
-[contributing]: https://github.com/carpentries/instructor-training/blob/gh-pages/CONTRIBUTING.md
+[contributing]: https://github.com/carpentries/instructor-training/blob/main/CONTRIBUTING.md
 [handbook-amy]: https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#accessing-and-updating-your-instructor-profile
 [git-blog]: https://carpentries.org/blog/2020/05/conversations-teaching-git-github/
 [contact-page]: https://carpentries.org/contact/

--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -250,7 +250,7 @@ work for a checkout demo. Be sure to give yourself time to change course if your
 
 ### Sign-up and Set-up
 
-To sign up, select a session that works for you on [the Instructor Training Demonstration Sessions Etherpad]({{page.demopad}}), and add
+To sign up, select a session that works for you on [the Instructor Training Demonstration Sessions Etherpad](https://pad.carpentries.org/teaching-demos), and add
 your name and a link to your lesson of choice to that Etherpad. Be sure to **double check the time in your local time zone** by clicking on the converter link posted. Also, examine the demo description to ensure that it is not a special session targeting a specific sub-community or
 language (unless you are part of that target group).
 

--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -305,10 +305,10 @@ Approximately 1-2 weeks after your last step is complete, you should receive an 
 [discussion]: https://pad.carpentries.org/community-discussions
 [pad-of-pads]: https://pad.carpentries.org/pad-of-pads
 [mentoring]: https://docs.carpentries.org/topic_folders/instructor_development/mentoring_groups.html
-[demos-rubric]: https://carpentries.github.io/instructor-training/demos_rubric/
+[demos-rubric]: https://carpentries.github.io/instructor-training/demos_rubric
 [r-gapminder]: https://swcarpentry.github.io/r-novice-gapminder/
-[start-points]: https://carpentries.github.io/instructor-training/demo_lessons/index.html
-[r-gapminder-episode]: https://swcarpentry.github.io/r-novice-gapminder/04-data-structures-part1/index.html
+[start-points]: https://carpentries.github.io/instructor-training/demo_lessons
+[r-gapminder-episode]: https://swcarpentry.github.io/r-novice-gapminder/04-data-structures-part1
 [trainee-profile]: https://amy.carpentries.org/workshops/trainee-dashboard/
 [instructors-page]: https://carpentries.org/instructors/
 

--- a/learners/training_calendar.md
+++ b/learners/training_calendar.md
@@ -8,7 +8,7 @@ This training is designed for people who want to become certified Carpentries in
 
 For more information about what will be covered at this training as well as a sample schedule, check out our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/).
 
-In addition to Instructor Training, certification as a Carpentries Instructor includes 3 short ‘checkout' steps. For more details, see our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout/index.html).
+In addition to Instructor Training, certification as a Carpentries Instructor includes 3 short ‘checkout' steps. For more details, see our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout).
 
 ### How to Register for an Instructor Training
 


### PR DESCRIPTION
I am wondering about the link to the Etherpad that had to be replaced here, and whether we are going to find other problems related to that one. I can't recall where those links used to live in the repository. I will merge this promptly because it's important that these links work, but also tagging @carpentries/core-team-curriculum in case of advice!