### PR TITLE
Remove 'programming'

### DIFF
--- a/episodes/17-live.md
+++ b/episodes/17-live.md
@@ -23,7 +23,7 @@ finish this section by practicing ourselves and providing feedback for each othe
 
 :::::::::::::::::::::::::::::::::::::::: questions
 
-- Why do we teach programming using participatory live coding?
+- Why do we teach using participatory live coding?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
The Carpentries do not only teach programming and use participatory live coding to teach other skills as well. Thus, we should not specifically mention programming in the overview question.