### PR TITLE
Add calendar to info on checkout

### DIFF
--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -142,7 +142,7 @@ In some cases, a Community Discussion meeting may be used for regional community
 with representatives from specific Carpentries committees or subcommunities, or to address a theme of special interest to our
 community.
 
-When signing up on the [Community Discussion Etherpad][discussion], be sure to examine the description of your event carefully. Also, **take care to double check
+When signing up on the [Community Discussion Etherpad][discussion], be sure to examine the description of your event carefully. Upcoming Community Discussions are also shown on the [Community Events Calendar][community-calendar], which can make the dates and tAlso, **take care to double check
 the time zone**, and mark your calendar after signing up! At the time of the event, the Zoom link may be found at the top
 of that Etherpad.
 
@@ -251,7 +251,7 @@ work for a checkout demo. Be sure to give yourself time to change course if your
 ### Sign-up and Set-up
 
 To sign up, select a session that works for you on [the Instructor Training Demonstration Sessions Etherpad](https://pad.carpentries.org/teaching-demos), and add
-your name and a link to your lesson of choice to that Etherpad. Be sure to **double check the time in your local time zone** by clicking on the converter link posted. Also, examine the demo description to ensure that it is not a special session targeting a specific sub-community or
+your name and a link to your lesson of choice to that Etherpad. y-calendar], which can make the dates and times easier to see. Be sure to **double check the time in your local time zone** by clicking on the converter link posted in the Etherpad. Also, examine the demo description to ensure that it is not a special session targeting a specific sub-community or
 language (unless you are part of that target group).
 
 The link to connect to the video conference is at the top of the Teaching Demos Etherpad.
@@ -311,6 +311,7 @@ Approximately 1-2 weeks after your last step is complete, you should receive an 
 [r-gapminder-episode]: https://swcarpentry.github.io/r-novice-gapminder/04-data-structures-part1
 [trainee-profile]: https://amy.carpentries.org/workshops/trainee-dashboard/
 [instructors-page]: https://carpentries.org/instructors/
+[community-calendar]: https://carpentries.org/community/#community-events
 
 
 

--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -142,7 +142,7 @@ In some cases, a Community Discussion meeting may be used for regional community
 with representatives from specific Carpentries committees or subcommunities, or to address a theme of special interest to our
 community.
 
-When signing up on the [Community Discussion Etherpad][discussion], be sure to examine the description of your event carefully. Upcoming Community Discussions are also shown on the [Community Events Calendar][community-calendar], which can make the dates and tAlso, **take care to double check
+When signing up on the [Community Discussion Etherpad][discussion], be sure to examine the description of your event carefully. Upcoming Community Discussions are also shown on the [Community Events Calendar][community-calendar], which can make the dates and times easier to see. Also, **take care to double check
 the time zone**, and mark your calendar after signing up! At the time of the event, the Zoom link may be found at the top
 of that Etherpad.
 


### PR DESCRIPTION
Add community calendar links where relevant on checkout instructions. Closes #1512 (which changed the file in `/instructors` which no longer exists).