### PR TITLE
Fix text in headers

### DIFF
--- a/episodes/02-practice-learning.md
+++ b/episodes/02-practice-learning.md
@@ -5,10 +5,6 @@ teaching: 30
 exercises: 30
 ---
 
-We will now get started with a discussion of how learning works. We will begin with
-some key concepts from educational research and identify how these principles
-are put into practice in Carpentries workshops.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Compare and contrast the three stages of skill acquisition.
@@ -26,6 +22,10 @@ are put into practice in Carpentries workshops.
 - How can we help novices become competent practitioners?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+We will now get started with a discussion of how learning works. We will begin with
+some key concepts from educational research and identify how these principles
+are put into practice in Carpentries workshops.
 
 ## The Carpentries Pedagogical Model
 

--- a/episodes/04-expertise.md
+++ b/episodes/04-expertise.md
@@ -5,8 +5,6 @@ teaching: 20
 exercises: 25
 ---
 
-## Examining Your Expertise
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Explain what differentiates an expert from a competent practitioner.
@@ -22,6 +20,8 @@ exercises: 25
 - How are we (as Instructors) different from our learners and how does this impact our teaching?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+## Examining Your Expertise
 
 In the last episode, we discussed the transition from novice to competent practitioner through
 formation of a functional mental model. We now shift our attention to experts. The expert we want to talk about is you!

--- a/episodes/05-memory.md
+++ b/episodes/05-memory.md
@@ -5,10 +5,6 @@ teaching: 20
 exercises: 25
 ---
 
-In our final topic in how people learn (and therefore, how we can be more
-effective instructors), we will be learning more about human memory:
-specifically, how to remove unnecessary "load" in order to facilitate learning.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Remember the quantitative limit of human memory.
@@ -23,6 +19,10 @@ specifically, how to remove unnecessary "load" in order to facilitate learning.
 - How can we design instruction to work with, rather than against, memory constraints?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+In our final topic in how people learn (and therefore, how we can be more
+effective instructors), we will be learning more about human memory:
+specifically, how to remove unnecessary "load" in order to facilitate learning.
 
 ## Types of Memory
 

--- a/episodes/06-feedback.md
+++ b/episodes/06-feedback.md
@@ -5,13 +5,6 @@ teaching: 10
 exercises: 10
 ---
 
-We use formative assessment of learners during workshops to help track
-learners' progress and adjust our approach to teaching the content as needed.
-But formative assessment is not just for learners. As we will discuss in more detail
-[later](11-practice-teaching), teaching is also a skill that is improved
-through regular practice and feedback. We gather feedback from our learners
-at multiple points in the workshop and in different forms.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Describe three feedback mechanisms used in Carpentries workshops.
@@ -25,6 +18,13 @@ at multiple points in the workshop and in different forms.
 - How can I use this feedback to improve my teaching?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+We use formative assessment of learners during workshops to help track
+learners' progress and adjust our approach to teaching the content as needed.
+But formative assessment is not just for learners. As we will discuss in more detail
+[later](11-practice-teaching), teaching is also a skill that is improved
+through regular practice and feedback. We gather feedback from our learners
+at multiple points in the workshop and in different forms.
 
 ## Surveys
 

--- a/episodes/08-motivation.md
+++ b/episodes/08-motivation.md
@@ -5,8 +5,6 @@ teaching: 30
 exercises: 30
 ---
 
-## Motivation Matters
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Identify authentic tasks and explain why teaching them is important.
@@ -21,6 +19,8 @@ exercises: 30
 - How can we create a motivating environment for learners?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+## Motivation Matters
 
 Teaching and learning are not the same process. As we have seen, an instructor can make choices that facilitate the cognitive processes
 necessary for learning to occur. But **any technique can fall flat when learners are not motivated**. Worse, demotivation is contagious! Teaching or sharing a classroom with demotivated

--- a/episodes/09-eia.md
+++ b/episodes/09-eia.md
@@ -5,8 +5,6 @@ teaching: 20
 exercises: 20
 ---
 
-## A Positive Environment for All
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Identify instructional strategies that are consistent with universal design.
@@ -21,6 +19,8 @@ exercises: 20
 - What can I do enhance equity, inclusion, and accessibility in my workshop?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+## A Positive Environment for All
 
 As we have seen, there are many teaching practices that can make your workshop more positive and welcoming.
 However, no workshop occurs in a vacuum: everyone's experiences begin and end and are influenced by the world beyond.

--- a/episodes/11-practice-teaching.md
+++ b/episodes/11-practice-teaching.md
@@ -5,13 +5,6 @@ teaching: 20
 exercises: 40
 ---
 
-So far, we have focused on how we can be effective instructors by understanding
-how people learn and how to create a positive classroom environment, covering
-two of our primary goals in helping you become a certified Carpentries Instructor.
-Now our focus will shift to developing additional teaching skills that you can
-use in a Carpentries workshop setting, starting with the process of "lesson study",
-or teaching observation and feedback.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Use peer-to-peer lesson practice to transform your instruction.
@@ -25,6 +18,13 @@ or teaching observation and feedback.
 - How can I improve my teaching?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+So far, we have focused on how we can be effective instructors by understanding
+how people learn and how to create a positive classroom environment, covering
+two of our primary goals in helping you become a certified Carpentries Instructor.
+Now our focus will shift to developing additional teaching skills that you can
+use in a Carpentries workshop setting, starting with the process of "lesson study",
+or teaching observation and feedback.
 
 ## Lesson Study: Applying a Growth Mindset to Teaching
 

--- a/episodes/12-homework.md
+++ b/episodes/12-homework.md
@@ -17,6 +17,7 @@ exercises: 15
 - What needs to be done to prepare for the next part of the workshop?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+  
 In the first half of this workshop we have focused on understanding some core findings of pedagogical research about how the learning process
 works and the importance of creating a positive classroom environment. We also introduced the idea of lesson study
 and gave some opportunities to practice teaching. In the remaining parts of the training, we will continue our discussions of

--- a/episodes/12-homework.md
+++ b/episodes/12-homework.md
@@ -4,12 +4,6 @@ teaching: 5
 exercises: 15
 ---
 
-In the first half of this workshop we have focused on understanding some core findings of pedagogical research about how the learning process
-works and the importance of creating a positive classroom environment. We also introduced the idea of lesson study
-and gave some opportunities to practice teaching. In the remaining parts of the training, we will continue our discussions of
-how we build teaching skill and will have more chances for practice and feedback. We will also
-look in some depth at how The Carpentries operates to prepare you for the logistics of teaching a workshop.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Describe overnight homework.
@@ -23,6 +17,12 @@ look in some depth at how The Carpentries operates to prepare you for the logist
 - What needs to be done to prepare for the next part of the workshop?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+In the first half of this workshop we have focused on understanding some core findings of pedagogical research about how the learning process
+works and the importance of creating a positive classroom environment. We also introduced the idea of lesson study
+and gave some opportunities to practice teaching. In the remaining parts of the training, we will continue our discussions of
+how we build teaching skill and will have more chances for practice and feedback. We will also
+look in some depth at how The Carpentries operates to prepare you for the logistics of teaching a workshop.
+
 
 To prepare for our next session, please:
 

--- a/episodes/13-second-welcome.md
+++ b/episodes/13-second-welcome.md
@@ -5,9 +5,6 @@ teaching: 5
 exercises: 5
 ---
 
-To refresh as we enter the second half of this workshop, the goal of this training is prepare
-you to be a certified Carpentries Instructor, which includes the following:
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Review main points we discussed in parts 1 and 2.
@@ -21,6 +18,9 @@ you to be a certified Carpentries Instructor, which includes the following:
 - What will we focus on next?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+To refresh as we enter the second half of this workshop, the goal of this training is prepare
+you to be a certified Carpentries Instructor, which includes the following:
 
 - be familiar with and understand how to apply research-based teaching principles,
   especially as they apply to The Carpentries audience.

--- a/episodes/14-checkout.md
+++ b/episodes/14-checkout.md
@@ -4,9 +4,6 @@ teaching: 15
 exercises: 15
 ---
 
-In this short episode, we will take a moment to review the actions you will
-need to take after this training to become a fully certified Carpentries Instructor.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Describe the final steps required to qualify as an Instructor.
@@ -19,6 +16,9 @@ need to take after this training to become a fully certified Carpentries Instruc
 - What do I need to do to finish certifying as a Carpentries Instructor?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+  
+In this short episode, we will take a moment to review the actions you will
+need to take after this training to become a fully certified Carpentries Instructor.
 
 ## Instructor Checkout
 

--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -5,14 +5,6 @@ teaching: 20
 exercises: 25
 ---
 
-In becoming a certified [Carpentries Instructor](https://carpentries.org/instructors/),
-you are also becoming part of a community of like-minded volunteers. Our most
-active members draw upon this community for support and mentorship, pursuing goals that
-matter to them and creating relationships across the globe.
-This section provides some background on
-[The Carpentries](https://carpentries.org/) organization, how we are structured, and a few
-ways you might wish to participate (including by teaching workshops!).
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
 
 - CK: Not an "official" exercise, but after explaining the workshops and how to run them,
@@ -47,6 +39,14 @@ ways you might wish to participate (including by teaching workshops!).
 - How do you run a Carpentries workshop?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+  
+In becoming a certified [Carpentries Instructor](https://carpentries.org/instructors/),
+you are also becoming part of a community of like-minded volunteers. Our most
+active members draw upon this community for support and mentorship, pursuing goals that
+matter to them and creating relationships across the globe.
+This section provides some background on
+[The Carpentries](https://carpentries.org/) organization, how we are structured, and a few
+ways you might wish to participate (including by teaching workshops!).
 
 ## A Brief History
 

--- a/episodes/17-live.md
+++ b/episodes/17-live.md
@@ -5,14 +5,6 @@ block: Building Teaching Skill
 teaching: 20
 exercises: 45
 ---
-
-One of the cornerstones of The Carpentries teaching is live
-coding: *instructors do not use slides to teach coding*, but work through the lesson material,
-typing in the code or instructions, with the workshop participants following
-along. This section explains how it works, why we use it, and
-gives general tips for an effective participatory live coding presentation. We will
-finish this section by practicing ourselves and providing feedback for each other.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Explain the advantages and limitations of participatory live coding.
@@ -26,6 +18,13 @@ finish this section by practicing ourselves and providing feedback for each othe
 - Why do we teach using participatory live coding?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+  
+One of the cornerstones of The Carpentries teaching is live
+coding: *instructors do not use slides to teach coding*, but work through the lesson material,
+typing in the code or instructions, with the workshop participants following
+along. This section explains how it works, why we use it, and
+gives general tips for an effective participatory live coding presentation. We will
+finish this section by practicing ourselves and providing feedback for each other.
 
 ## Why Participatory Live Coding?
 

--- a/episodes/20-performance.md
+++ b/episodes/20-performance.md
@@ -5,9 +5,6 @@ teaching: 20
 exercises: 25
 ---
 
-Continuing our theme of developing practical Carpentries teaching skills,
-this section provides another chance to practice live coding, to go through the
-process of observing and giving feedback, and to make changes to how we teach based on the feedback of others.
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
@@ -20,6 +17,10 @@ process of observing and giving feedback, and to make changes to how we teach ba
 - How did you change your teaching in response to feedback?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+  
+Continuing our theme of developing practical Carpentries teaching skills,
+this section provides another chance to practice live coding, to go through the
+process of observing and giving feedback, and to make changes to how we teach based on the feedback of others.
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 

--- a/episodes/21-management.md
+++ b/episodes/21-management.md
@@ -5,8 +5,6 @@ teaching: 30
 exercises: 40
 ---
 
-## Never Teach Alone
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Identify potential challenges of teaching learners with very different backgrounds and skill levels.
@@ -24,6 +22,8 @@ exercises: 40
 - How does an instructional team prepare for a workshop?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+## Never Teach Alone
 
 One of the greatest strengths of Carpentries workshops compared with many other instructional settings is that workshops are prepared and executed
 by more than one person. We ask that at least two Instructors teach in every workshop, and some workshops may have many more! During the workshop,

--- a/episodes/23-introductions.md
+++ b/episodes/23-introductions.md
@@ -5,16 +5,6 @@ teaching: 10
 exercises: 30
 ---
 
-When preparing to teach a workshop, it is normal to focus on the content. We hope that our discussions so far have also encouraged you to prepare your delivery,
-creating plans to listen and respond to learners during a workshop. But within that, there are two time points that make a big difference to a
-workshop experience: the introduction and the conclusion. 
-
-Because these take time away from content instruction, it can be tempting to avoid investing precious
-preparation and class time to these sections. However, a strong introduction sets the tone for your workshop, teaches learners how to engage, and inspires
-confidence that learners will get what they need. A solid conclusion helps learners to solidify what they have learned and plan their next steps, and sends 
-everyone -- including Instructors and Helpers -- home with a sense of accomplishment. In this section, we will work together to identify ingredients that can
-make these moments stand out and dedicate some practice time as well.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Connect goals of an introduction with options for content and delivery.
@@ -28,6 +18,16 @@ make these moments stand out and dedicate some practice time as well.
 - How do you actually start a workshop?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+  
+When preparing to teach a workshop, it is normal to focus on the content. We hope that our discussions so far have also encouraged you to prepare your delivery,
+creating plans to listen and respond to learners during a workshop. But within that, there are two time points that make a big difference to a
+workshop experience: the introduction and the conclusion. 
+
+Because these take time away from content instruction, it can be tempting to avoid investing precious
+preparation and class time to these sections. However, a strong introduction sets the tone for your workshop, teaches learners how to engage, and inspires
+confidence that learners will get what they need. A solid conclusion helps learners to solidify what they have learned and plan their next steps, and sends 
+everyone -- including Instructors and Helpers -- home with a sense of accomplishment. In this section, we will work together to identify ingredients that can
+make these moments stand out and dedicate some practice time as well.
 
 ## Launching your Workshop: The Introduction
 

--- a/episodes/24-practices.md
+++ b/episodes/24-practices.md
@@ -4,8 +4,6 @@ teaching: 5
 exercises: 15
 ---
 
-We are almost done with our training!  At this point, we have covered many, many topics
-around teaching and learning, especially in the context of Carpentries workshops.
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
@@ -18,7 +16,11 @@ around teaching and learning, especially in the context of Carpentries workshops
 - How are the teaching practices we have learned used in our workshops?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+  
+We are almost done with our training!  At this point, we have covered many, many topics
+around teaching and learning, especially in the context of Carpentries workshops.
 
+  
 Carpentries instructors use a set of teaching techniques based on evidence from
 educational research. We have talked about some of these techniques explicitly
 (e.g. participatory live coding and formative assessment), and others we have been modeling throughout

--- a/episodes/25-wrap-up.md
+++ b/episodes/25-wrap-up.md
@@ -4,10 +4,6 @@ teaching: 0
 exercises: 10
 ---
 
-Just as in our technical workshops, we collect feedback at the end of Instructor Training.
-This will help your Trainers continue to develop *their* skills and to participate in continually improving our curriculum. The Carpentries Surveys also
-provide vital information to The Carpentries Core Team and help us to report to our funders.
-
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Reflect on the course.
@@ -22,6 +18,10 @@ provide vital information to The Carpentries Core Team and help us to report to 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::  challenge
+  
+Just as in our technical workshops, we collect feedback at the end of Instructor Training.
+This will help your Trainers continue to develop *their* skills and to participate in continually improving our curriculum. The Carpentries Surveys also
+provide vital information to The Carpentries Core Team and help us to report to our funders.
 
 ## One Up, One Down
 


### PR DESCRIPTION
I noticed that the Workbench had positioned some content from the top of each page *above* the lesson questions and objectives. In a couple of cases this kinda worked, but in most cases it really didn't. I changed them all -- in the future we can consider whether we want to exercise the option of positioning a summary of some kind above the questions/objectives box.

@zkamvar FYI in case this affects other lessons - sorry I didn't notice this during the beta!