### PR TITLE
Add Excel option to suggested practice episodes

### DIFF
--- a/episodes/12-homework.md
+++ b/episodes/12-homework.md
@@ -38,21 +38,17 @@ To prepare for our next session, please:
   Remember, imperfect presentations can generate useful feedback!
   If you have not yet selected an episode to focus on and would like a recommendation, consider one of the following:
   
-  - Data Carpentry
-    
+  - Data Carpentry   
     - [Exploring Data with OpenRefine](https://datacarpentry.org/OpenRefine-ecology-lesson/03-exploring-data.html)
     - [Basic Queries in SQL](https://datacarpentry.org/sql-ecology-lesson/01-sql-basic-queries.html)
     - [Starting with Data in R](https://datacarpentry.org/R-ecology-lesson/02-starting-with-data.html)
     - [Starting with Data in Python](https://datacarpentry.org/python-ecology-lesson/02-starting-with-data.html)
-  
-  - Library Carpentry
-    
+    - [Dates as Data in Excel](https://datacarpentry.org/spreadsheet-ecology-lesson/03-dates-as-data.html)
+  - Library Carpentry    
     - [Working with Files and Directories in the Unix Shell](https://librarycarpentry.github.io/lc-shell/03-working-with-files-and-folders.html)
     - [Faceting and filtering in Open Refine](https://librarycarpentry.github.io/lc-open-refine/04-faceting-and-filtering.html)
     - [For loops in Python](https://librarycarpentry.github.io/lc-python-intro/12-for-loops.html)
-  
-  - Software Carpentry
-    
+  - Software Carpentry    
     - [Working with Files and Directories in the Unix Shell](https://swcarpentry.github.io/shell-novice/03-create.html)
     - [Tracking Changes in Git](https://swcarpentry.github.io/git-novice/04-changes.html)
     - [Selecting Data in SQL](https://swcarpentry.github.io/sql-novice-survey/01-select.html)

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -45,25 +45,21 @@ If you have any questions about the workshop, the reading material, or anything 
 
 If you are having trouble choosing an episode, we recommend choosing one of the following:
 
-**Data Carpentry**
-
-- [Exploring Data with OpenRefine](https://datacarpentry.org/OpenRefine-ecology-lesson/03-exploring-data.html)
-- [Basic Queries in SQL](https://datacarpentry.org/sql-ecology-lesson/01-sql-basic-queries.html)
-- [Starting with Data in R](https://datacarpentry.org/R-ecology-lesson/02-starting-with-data.html)
-- [Starting with Data in Python](https://datacarpentry.org/python-ecology-lesson/02-starting-with-data)
-
-**Software Carpentry**
-
-- [Working with Files and Directories in the Unix Shell](https://swcarpentry.github.io/shell-novice/03-create.html)
-- [Tracking Changes in Git](https://swcarpentry.github.io/git-novice/04-changes.html)
-- [Selecting Data in SQL](https://swcarpentry.github.io/sql-novice-survey/01-select.html)
-- [Repeating Actions with Loops in Python](https://swcarpentry.github.io/python-novice-inflammation/05-loop.html)
-- [Exploring Data Frames in R](https://swcarpentry.github.io/r-novice-gapminder/05-data-structures-part2.html)
-
-**Library Carpentry**
-
-- [Working with Files and Directories](https://librarycarpentry.org/lc-shell/03-working-with-files-and-folders.html)
-- [Automating the Tedious with Loops](https://librarycarpentry.github.io/lc-shell/04-loops.html)
-- [Importing Data into OpenRefine](https://librarycarpentry.org/lc-open-refine/02-importing-data.html)
+ - Data Carpentry   
+    - [Exploring Data with OpenRefine](https://datacarpentry.org/OpenRefine-ecology-lesson/03-exploring-data.html)
+    - [Basic Queries in SQL](https://datacarpentry.org/sql-ecology-lesson/01-sql-basic-queries.html)
+    - [Starting with Data in R](https://datacarpentry.org/R-ecology-lesson/02-starting-with-data.html)
+    - [Starting with Data in Python](https://datacarpentry.org/python-ecology-lesson/02-starting-with-data.html)
+    - [Dates as Data in Excel](https://datacarpentry.org/spreadsheet-ecology-lesson/03-dates-as-data.html)
+  - Library Carpentry    
+    - [Working with Files and Directories in the Unix Shell](https://librarycarpentry.github.io/lc-shell/03-working-with-files-and-folders.html)
+    - [Faceting and filtering in Open Refine](https://librarycarpentry.github.io/lc-open-refine/04-faceting-and-filtering.html)
+    - [For loops in Python](https://librarycarpentry.github.io/lc-python-intro/12-for-loops.html)
+  - Software Carpentry    
+    - [Working with Files and Directories in the Unix Shell](https://swcarpentry.github.io/shell-novice/03-create.html)
+    - [Tracking Changes in Git](https://swcarpentry.github.io/git-novice/04-changes.html)
+    - [Selecting Data in SQL](https://swcarpentry.github.io/sql-novice-survey/01-select.html)
+    - [Repeating Actions with Loops in Python](https://swcarpentry.github.io/python-novice-inflammation/05-loop.html)
+    - [Exploring Data Frames in R](https://swcarpentry.github.io/r-novice-gapminder/05-data-structures-part2.html)
 
 


### PR DESCRIPTION
Add an Excel option to practice episodes to help non-coders with no openRefine experience find a lesson. Also clean up formatting to be treat lessons as one list. Also standardizes names/format/order between setup and homework episodes.