### PR TITLE
Update URL in link text

### DIFF
--- a/episodes/20-performance.md
+++ b/episodes/20-performance.md
@@ -28,7 +28,7 @@ process of observing and giving feedback, and to make changes to how we teach ba
 
 1. Before splitting into groups, read the rubric that is given to Instructor Trainers
   as a suggested framework for evaluating the online teaching demonstration sessions that are part of Instructor checkout.  
-  [https://carpentries.github.io/instructor-training/demos\_rubric/](demos_rubric.md). (Note: demos are not scored, so this rubric is for
+  [https://carpentries.github.io/instructor-training/demos_rubric.html](demos_rubric.md). (Note: demos are not scored, so this rubric is for
   advisory purposes only.)
   What questions do you have?
 2. Return to your groups and repeat the previous live coding exercise, re-teaching the same content as before.


### PR DESCRIPTION
_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

In [the _Round Two_ exercise](https://carpentries.github.io/instructor-training/20-performance.html#round-two) of _More Practice Live Coding_, the text of the link to the rubric for demos still shows the old pre-Workbench URL, even though the link itself points to the correct location. This PR fixes that by updating the link text to match the new target URL.
