### PR TITLE
Suggest to sign-post Q&A periods

### DIFF
--- a/episodes/04-expertise.md
+++ b/episodes/04-expertise.md
@@ -247,6 +247,7 @@ moving on, the more this implication is magnified.
 Instead, consider asking "What questions do you have?" and leaving a healthy pause for consideration.
 This firmly establishes an expectation that
 people will, indeed, have questions, and should challenge themselves to formulate them.
+By additionally sign-posting upcoming Q&A periods, learners can mentally prepare and are less put on the spot.
 
 ## You Are Not Your Learners
 


### PR DESCRIPTION
We could suggest to sign-post Q&A periods, because it can help learners to mentally prepare for them and not feel put on the spot.

This should, however, not suggest that you should not allow questions at any time, which for some might be implied by the suggested text.

This was a suggestion by a participant in our recent instructor training.