### PR TITLE
Fix typo in cutting call out 

### DIFF
--- a/episodes/18-preparation.md
+++ b/episodes/18-preparation.md
@@ -41,7 +41,7 @@ we therefore suggest setting aside time *before* deeply reviewing your technical
 
 ## A note on cutting
 
-This episode is a common place to Trainers to cut while preparing to teach.
+This episode is a common place for Trainers to cut while preparing to teach.
 That's not because this is not important -- this page is a valuable resource -- but we feel this
 is one of the sections that trainees can use effectively as a resource when actually preparing
 for a workshop, even without spending a lot of time doing activities on this material during

--- a/episodes/18-preparation.md
+++ b/episodes/18-preparation.md
@@ -49,6 +49,14 @@ their Instructor Training event.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+## Using this page as a resource
+
+Your trainers may not cover everything here during Instructor Training because the material is designed to be a valuable ongoing reference. We encourage you to keep this lesson handy as a resource when preparing for a workshop.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 ## Anticipate Your Audience
 
 To teach effectively, you have to know *who* you are teaching. You may have a broad idea about the type of audience you expect. You may

--- a/episodes/18-preparation.md
+++ b/episodes/18-preparation.md
@@ -37,7 +37,7 @@ demonstrating how you Google things may earn surprisingly positive feedback! In 
 to attend to the audience usually has much more serious consequences for learning and morale. When you prepare to teach,
 we therefore suggest setting aside time *before* deeply reviewing your technical content to **plan your approach to instruction**.
 
-:::::::::::::::::::::::::::::::::::::::::  callout
+:::::::::::::::::::::::::::::::::::::::::  instructor
 
 ## A note on cutting
 

--- a/episodes/18-preparation.md
+++ b/episodes/18-preparation.md
@@ -41,7 +41,7 @@ we therefore suggest setting aside time *before* deeply reviewing your technical
 
 ## A note on cutting
 
-This episode is a common place for Trainers to cut while preparing to teach.
+This episode is a common place for Trainers to cut parts of while preparing to teach.
 That's not because this is not important -- this page is a valuable resource -- but we feel this
 is one of the sections that trainees can use effectively as a resource when actually preparing
 for a workshop, even without spending a lot of time doing activities on this material during


### PR DESCRIPTION
attempts to fix #1642 


I did something slightly different than the suggestion, but i agree there was a typo in the box. 

I think leaving it at the top actually makes sense for two reasons:
1. in theory, trainees are coming back to this page as a reference after the workshop more often than reading it when they would not know what we mean by cutting, and having a warning at the top of the episode that the version they saw in their workshop may have been truncated
2.  it serves as an additional reminder to trainers that this episode is a good place to make up time if needed. While a trainer would see the entirety of the episode while preparing, I think at the top it is more likely to catch & support in real time a new trainer who might be nervous; that is the note to cut from this episode and reassurance that others cut here too, could help prevent someone from speeding up instead of cutting, but for that to work, the reminder has to be before the content that would be cut. 

If others 1) agree with that rationale 2) think it is worth making more findable,  we could put a (shortend; edited for clarity) version of that justification in the box too.