### PR TITLE
Rename "homework" to avoid evoking bad memories

### DIFF
--- a/episodes/12-homework.md
+++ b/episodes/12-homework.md
@@ -1,12 +1,12 @@
 ---
-title: End Part 2 and Homework
+title: End Part 2 and Preparation for the Next Part
 teaching: 5
 exercises: 15
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Describe overnight homework.
+- Describe overnight preparation.
 - Produce a paragraph, drawing, or diagram that summarizes what was taught to this point.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -124,7 +124,7 @@ helper-to-learner ratio for in-person workshops (not counting instructors) and m
 All Carpentries lesson
 materials are freely available under a permissive [open license](LICENSE.md).
 This means that you may use them in contexts outside of a Carpentries workshop (e.g. as material
-introduced into a longer course, as a standalone 2-3 hour session, as homework exercises, etc.)
+introduced into a longer course, as a standalone 2-3 hour session, as practice exercises, etc.)
 provided you cite the original source.
 
 It is only when you want to run a branded Carpentries workshop using the materials


### PR DESCRIPTION
Thank you @brownsarahm for suggesting  to rename "homework" to evoke less bad memories at #1159 
Based on the pr-requestd label, here is the pull request.

Changelog:
Replaced "homework" with
"preparation.." phrases inthe episode 12-homework
and "practice " in the episode 15-carpentries.
Closes #1159