### PR TITLE
Add alternative to 2-day workshops

### DIFF
--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -86,7 +86,7 @@ Their aligned missions are accomplished by running accessible, inclusive trainin
 Similarities between Data Carpentry, Library Carpentry, and Software Carpentry workshops include:
 
 - a focus on technical skills,
-- a two-day format taught by volunteer instructors, and
+- a two to four day format taught by volunteer instructors, and
 - a focus on filling gaps in current training for learners.
 
 The major differences between Data Carpentry, Library Carpentry, and Software Carpentry workshops

--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -86,7 +86,7 @@ Their aligned missions are accomplished by running accessible, inclusive trainin
 Similarities between Data Carpentry, Library Carpentry, and Software Carpentry workshops include:
 
 - a focus on technical skills,
-- a two to four day format taught by volunteer instructors, and
+- a two full day or four half day format taught by volunteer instructors, and
 - a focus on filling gaps in current training for learners.
 
 The major differences between Data Carpentry, Library Carpentry, and Software Carpentry workshops


### PR DESCRIPTION
Adjust statement on commonality of lesson programs to indicate all share a "two to four day" format instead of just 2-day. This reflects current practice.
