### PR TITLE
add solution linking to glossary

### DIFF
--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -159,6 +159,20 @@ As a class or in groups, see how many of the following terms you can define.
 
 This should take about 5 minutes.
 
+::::::::::::::::::::::: solution
+
+### Links to definitions
+These terms are defined in our Community Glossary.
+
+- [Lesson](https://github.com/carpentries/community-development/blob/main/glossary.md#lesson)
+- [Episode](https://github.com/carpentries/community-development/blob/main/glossary.md#episode-lesson-episode)
+- [Workshop](https://github.com/carpentries/community-development/blob/main/glossary.md#workshop)
+- [Lesson Program](https://github.com/carpentries/community-development/blob/main/glossary.md#lesson-program)
+- [Instructor](https://github.com/carpentries/community-development/blob/main/glossary.md#instructor)
+- [(Instructor) Trainer](https://github.com/carpentries/community-development/blob/main/glossary.md#instructor-trainer)
+
+::::::::::::::::::::::::::::::::
+
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## How to Organise a Carpentries Workshop Locally


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Closes #1655


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This adds a solution box to [the _Test yourself!_ exercise](https://carpentries.github.io/instructor-training/15-carpentries.html#test-yourself), containing links to the terms as defined in [the Community Glossary](https://github.com/carpentries/community-development/blob/main/glossary.md). (HT to @kariljordan for suggesting this approach.)

Please let me know if you would prefer the terms to be defined in the solution box itself: happy to update. My rationale for linking out was to avoid content rot as definitions diverge in the glossary.

