### PR TITLE
Fix link to https://www.liberquarterly.eu/article/10.18352/lq.10176/

### DIFF
--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -313,7 +313,7 @@ This exercise should take about 5 minutes.
 [coreteam-page]: https://carpentries.org/team/
 [F1000]: https://f1000research.com/articles/3-62/v2
 [IJDC]: https://ijdc.net/index.php/ijdc/article/view/10.1.135
-[LIBERQ]: https://www.liberquarterly.eu/article/10.18352/lq.10176/
+[LIBERQ]: https://doi.org/10.18352/lq.10176
 [values-page]: https://carpentries.org/values/
 [workshopsreq-page]: https://carpentries.org/workshops/#workshop-core
 [docs-workshop-checklists]: https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html


### PR DESCRIPTION
I ran a markdown link checker https://github.com/tcort/markdown-link-check and then confirmed by hand if any links were broken. I found one, which I fixed here!

Check results here [md-links.txt](https://github.com/user-attachments/files/15900541/md-links.txt) - quite a few false positives.
