### PR TITLE
Add link to excalidraw for concept organizer exercise

### DIFF
--- a/episodes/24-practices.md
+++ b/episodes/24-practices.md
@@ -97,6 +97,15 @@ If you feel you have finished organizing your thoughts, try the next exercise.
 
 This exercise should take about 5 minutes.
 
+::::: hint
+
+## Excalidraw
+
+The online tool we used in the mental models exercise is [Excalidraw](https://excalidraw.com/), in case you'd like to use it here.
+
+
+:::::
+
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::  challenge


### PR DESCRIPTION
Adds a link to Excalidraw (the same tool as the concept map exercise) in a hint. Wording maybe could be improved by someone else.