### PR TITLE
remove dismissive language

### DIFF
--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -45,12 +45,18 @@ One reason to avoid pressuring people to share them is to allow people to share 
 gender identity only when they feel ready to.
 It is, however, necessary for all participants to use pronouns and names as listed when participants provide them.
 
-These resources may be helpful for further reading to learn more about using pronouns:
+::::: spoiler
+
+### Further reading on pronouns
+
+The resources below can provide additional guidance on respectful pronoun usage:
 
 - The proper use of pronouns in language: [https://lgbt.ucsf.edu/pronounsmatter](https://lgbt.ucsf.edu/pronounsmatter)
 - The importance of using pronouns: [https://www.pronouns.org/](https://www.pronouns.org/)
 - How to use personal pronouns: [https://www.pronouns.org/how](https://www.pronouns.org/how)
 - How to deal with situations when you use the wrong pronoun: [https://www.pronouns.org/mistakes](https://www.pronouns.org/mistakes)
+
+:::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -45,8 +45,7 @@ One reason to avoid pressuring people to share them is to allow people to share 
 gender identity only when they feel ready to.
 It is, however, necessary for all participants to use pronouns and names as listed when participants provide them.
 
-For those unfamiliar with the practice of sharing pronouns, these resources may be helpful
-for further reading:
+These resources may be helpful for further reading to learn more about using pronouns:
 
 - The proper use of pronouns in language: [https://lgbt.ucsf.edu/pronounsmatter](https://lgbt.ucsf.edu/pronounsmatter)
 - The importance of using pronouns: [https://www.pronouns.org/](https://www.pronouns.org/)


### PR DESCRIPTION
The curriculum offers some resources about using pronouns.  The language "For those unfamiliar with..." reminds some users that there is a concept they are unfamiliar with, and does not seem to have any other purpose.  

I am recommending removing that language and only offering the resources.  If we are offering the resources, we should offer them as they are, without contextualizing that some people don't know about them.
