### PR TITLE
Add a general information page about the training

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,6 +87,7 @@ episodes:
 
 # Information for Learners
 learners: 
+- training_info.md
 - training_calendar.md
 - checkout.md
 - demo_lessons.md

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -24,8 +24,8 @@ Details about the Instructor Trainer role including the application process, dut
   - How do you ensure that all trainees stay engaged and participate?
   - How can Trainers help each other (at times when we are not the active Trainer)? How should we communicate with each other during the training?
   - How can we address trainee challenges? These may include internet connectivity problems, distractions caused by working from home, etc.
-- Create an event Etherpad using the [Etherpad template][etherpad-template]). (Google Doc [template](https://docs.google.com/document/d/1P_w1rgdVk4SpXvILSS-ZKz8Ujqklfujpc_zHf8D-G1A/edit?usp=sharing) may not be maintained) and a workshop website (using the [training template][training-template]). **If you find areas where the template needs to be updated,** please email suggested changes to instructor.training@carpentries.org. You are welcome to make quick fixes (e.g. links) yourself
-- Send Etherpad/Google Doc and website links to [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).
+- Create an event Etherpad using the [Etherpad template][etherpad-template]). (Google Doc [template](https://docs.google.com/document/d/1P_w1rgdVk4SpXvILSS-ZKz8Ujqklfujpc_zHf8D-G1A/edit?usp=sharing) may not be maintained) 
+- Send Etherpad/Google Doc links to [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).
 - Consider forking the Instructor Training curriculum and doing all of your preparation work based on your fork so that any changes do not impact your preparation.
 
 ### One Week before the Event

--- a/learners/training_info.md
+++ b/learners/training_info.md
@@ -1,0 +1,157 @@
+## General Information
+[The Carpentries](https://carpentries.org) is a community of practice centered around teaching foundational coding and data science skills to researchers worldwide. 
+This Instructor Training event is designed to prepare trainees to certify and participate as Carpentries Instructors. 
+However, much of our curriculum focuses on educational principles that apply across a wide variety of contexts. 
+We also welcome participants who do not plan to certify but simply wish to become a better teacher.
+
+Carpentries Instructor Training has the following goals:
+
+* Introduce you to evidence-based teaching practices.
+* Teach you how to create a positive environment for learners at your workshops.
+* Provide opportunities for you to practice and build your teaching skills.
+* Help you become integrated into the Carpentries community.
+* Prepare you to use these teaching skills in teaching Carpentries workshops.
+
+Because we have only limited time, some things are beyond the scope of this training. 
+We will not be learning:
+
+* How to program in R or Python, use Git or SQL, or any of the other topics taught in [Data Carpentry](https://datacarpentry.org/), [Library Carpentry](https://librarycarpentry.org/), or [Software Carpentry](https://software-carpentry.org/) workshops.
+* How to create your own lessons from scratch. However, this Instructor Training serves as a good precursor to [The Carpentries Collaborative Lesson Development Training](https://carpentries.github.io/lesson-development-training/).
+
+Instructor Training events are hands-on throughout: short lessons alternate with individual and group practical exercises, including practice teaching sessions.
+This Instructor Training event is the first step towards certification as a Carpentries Instructor. 
+For more details on the other 3 steps, see the [Checkout Instructions](../learners/checkout.md) page.
+For more information, see our [Instructor Training Curriculum](../index.md).
+
+### Code of Conduct
+
+All participants are required to abide by The Carpentries [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+
+### Where
+Instructor Training is typically conducted using the Zoom video conferencing platform. 
+No log-in is needed.
+However, if you have not used Zoom before, please click the link a few minutes early as it may prompt you to install the Zoom app or browser extension.
+If you have registered to join an Instructor Training event, you should have received a connection link in the information email about your training event. 
+If you did not receive that email, please check your spam folder then email [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org) to request help.
+
+If your training event will take place in-person, you will receive details about the location directly from your Trainers before the event.
+
+#### Accessibility
+
+We are committed to making this training accessible to everybody.
+
+Materials will be provided in advance of the event.
+
+We do not require participants to provide documentation of disabilities or disclose any unnecessary personal information. 
+However, we do want to help create an inclusive, accessible experience for all participants.
+We encourage you to share any information that would be helpful to make your Carpentries experience accessible.
+To request an accommodation for this training, please fill out the [accommodation request form](https://carpentries.typeform.com/to/B2OSYaD0).
+If you have questions or need assistance with the accommodation form please [email us](mailto:team@carpentries.org).
+
+For in-person training events, organisers have checked that:
+
+* The room is wheelchair / scooter accessible.
+* Accessible restrooms are available.
+
+### How to Prepare for Instructor Training
+
+Please review [_Preparing for your training_](https://carpentries.github.io/instructor-training/#preparing-for-your-training) for complete instructions. 
+A brief summary of these instructions is as follows
+
+1. Complete our Pre-training Survey. You will receive a custom link for your event when you receive your connection information.
+1. Select a lesson to use for teaching practice sessions and prepare a 3 minute segment, spending no more than 20-30 minutes to prepare.
+1. Please read the following:
+    * [The Science of Learning](https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf)
+    * [The Carpentries 2023 Annual Report](https://carpentries.org/files/reports/AnnualReport2023.pdf)
+
+### Checkout: The Instructor Certification Process
+After the training event, we ask you to complete three follow-up tasks to become a certified Instructor.
+These requirements are detailed on our [Checkout Instructions](../learners/checkout.md) page and will be discussed at our training.
+
+### What to Bring to an In-Person Event
+[Most Instructor Training events take place online](#where).
+If your training will take place in-person, please bring a laptop that is Internet connected and has a functioning browser. 
+If you have it, a device for recording audio and video (mobile phones and laptops are OK) is useful as we are going to record one another teaching in pairs or threes. 
+It does not have to be high-quality, but it should be good enough that you can understand what someone is saying.
+
+### Attendance and Cancellation
+Trainees who miss more than 1 hour of the training may be marked absent.
+Instructor certification cannot be completed without full attendance at an Instructor Training event. 
+If you unexpectedly need to miss more than 1 hour of your event, please contact your Trainers using the details provided in the information email for your event or [email us](mailto:instructor.training@carpentries.org).
+
+For events in which registration occurs through The Carpentries via Eventbrite, cancellation may be performed in Eventbrite up to the start of the event.
+Canceled seats cannot be filled after the 1 week registration deadline for these events, so we ask that you only cancel if absolutely necessary.
+
+More information on our [cancellation and makeup policy](https://docs.carpentries.org/topic_folders/instructor_training/cancellations_and_makeups.html) is available in The Carpentries Handbook.
+
+### Contact
+Please contact your Trainers using the details provided in the information email for your event or [email us](mailto:instructor.training@carpentries.org) with questions about Instructor Training.
+
+
+## Training Materials and Schedule
+This website contains the curriculum for Instructor Training.
+Use the left sidebar to browse the content, and visit [the landing page in Instructor View](https://carpentries.github.io/instructor-training/instructor/index.html#schedule) for a sample schedule for a 2-day event.
+Note that many Instructor Training events take place over four half-days, and this schedule will not apply in those cases.
+
+<!--
+FOUR DAY SCHEDULE
+--->
+<!--
+
+<div class="row">
+  <div class="col-md-6">
+    <h3>Day 1</h3>
+    <table class="table table-striped">
+      <tr> <td>09:00</td> <td>Welcome </td> </tr>
+      <tr> <td>09:30</td> <td>Building Skill with Practice </td> </tr>
+      <tr> <td>10:30</td> <td>Break </td> </tr>
+      <tr> <td>10:45</td> <td>Expertise and Instruction </td> </tr>
+      <tr> <td>11:30</td> <td>Memory and Cognitive Load </td> </tr>
+      <tr> <td>12:15</td> <td>Building Skill with Feedback </td> </tr>
+      <tr> <td>12:35</td> <td>Finish day 1 </td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Day 2</h3>
+    <table class="table table-striped">
+      <tr> <td>13:35</td> <td>Motivation and Demotivation </td> </tr>
+      <tr> <td>14:35</td> <td>Equity, Inclusion, and Accessibility </td> </tr>
+      <tr> <td>15:15</td> <td>Break </td> </tr>
+      <tr> <td>15:30</td> <td>Teaching Is a Skill </td> </tr>
+      <tr> <td>16:30</td> <td>Wrap-up and Homework </td> </tr>
+      <tr> <td>16:50</td> <td>Finish day 2</td> </tr>
+    </table>
+  </div>
+</div>
+<div class="row">  
+  <div class="col-md-6">
+    <h3>Day 3</h3>
+    <table class="table table-striped">
+      <tr> <td>09:00</td> <td>Welcome Back </td> </tr>
+      <tr> <td>09:10</td> <td>Getting Started on Instructor Certification </td> </tr>
+      <tr> <td>09:40</td> <td>The Carpentries: How We Operate </td> </tr>
+      <tr> <td>10:25</td> <td>Break </td> </tr>
+      <tr> <td>10:40</td> <td>Live Coding Is a Skill </td> </tr>
+      <tr> <td>11:45</td> <td>Preparing to Teach </td> </tr>
+      <tr> <td>12:30</td> <td>Finish day 3 </td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Day 4</h3>
+    <table class="table table-striped">
+      <tr> <td>13:30</td> <td>More Practice Live Coding </td> </tr>
+      <tr> <td>14:15</td> <td>Working with Your Team</td> </tr>
+      <tr> <td>15:25</td> <td>Break </td> </tr>
+      <tr> <td>15:40</td> <td>Launches and Landings </td> </tr>
+      <tr> <td>16:20</td> <td>Putting it Together </td> </tr>
+      <tr> <td>16:40</td> <td>Wraping Up </td> </tr>
+      <tr> <td>16:50</td> <td>Post-Training Survey </td> </tr>
+      <tr> <td>17:05</td> <td>Finish </td> </tr>
+    </table>
+  </div>
+</div>
+
+-->
+
+### Collaborative Notes
+Trainers will share the link to an [_Etherpad_](https://github.com/carpentries/community-engagement/blob/main/glossary.md#etherpad) that can be used for chatting, collaborating on notes, and sharing URLs and bits of code during the training.

--- a/learners/training_info.md
+++ b/learners/training_info.md
@@ -1,3 +1,7 @@
+---
+title: 'Information: The Carpentries Instructor Training'
+---
+
 ## General Information
 [The Carpentries](https://carpentries.org) is a community of practice centered around teaching foundational coding and data science skills to researchers worldwide. 
 This Instructor Training event is designed to prepare trainees to certify and participate as Carpentries Instructors. 
@@ -92,66 +96,6 @@ Please contact your Trainers using the details provided in the information email
 This website contains the curriculum for Instructor Training.
 Use the left sidebar to browse the content, and visit [the landing page in Instructor View](https://carpentries.github.io/instructor-training/instructor/index.html#schedule) for a sample schedule for a 2-day event.
 Note that many Instructor Training events take place over four half-days, and this schedule will not apply in those cases.
-
-<!--
-FOUR DAY SCHEDULE
---->
-<!--
-
-<div class="row">
-  <div class="col-md-6">
-    <h3>Day 1</h3>
-    <table class="table table-striped">
-      <tr> <td>09:00</td> <td>Welcome </td> </tr>
-      <tr> <td>09:30</td> <td>Building Skill with Practice </td> </tr>
-      <tr> <td>10:30</td> <td>Break </td> </tr>
-      <tr> <td>10:45</td> <td>Expertise and Instruction </td> </tr>
-      <tr> <td>11:30</td> <td>Memory and Cognitive Load </td> </tr>
-      <tr> <td>12:15</td> <td>Building Skill with Feedback </td> </tr>
-      <tr> <td>12:35</td> <td>Finish day 1 </td> </tr>
-    </table>
-  </div>
-  <div class="col-md-6">
-    <h3>Day 2</h3>
-    <table class="table table-striped">
-      <tr> <td>13:35</td> <td>Motivation and Demotivation </td> </tr>
-      <tr> <td>14:35</td> <td>Equity, Inclusion, and Accessibility </td> </tr>
-      <tr> <td>15:15</td> <td>Break </td> </tr>
-      <tr> <td>15:30</td> <td>Teaching Is a Skill </td> </tr>
-      <tr> <td>16:30</td> <td>Wrap-up and Homework </td> </tr>
-      <tr> <td>16:50</td> <td>Finish day 2</td> </tr>
-    </table>
-  </div>
-</div>
-<div class="row">  
-  <div class="col-md-6">
-    <h3>Day 3</h3>
-    <table class="table table-striped">
-      <tr> <td>09:00</td> <td>Welcome Back </td> </tr>
-      <tr> <td>09:10</td> <td>Getting Started on Instructor Certification </td> </tr>
-      <tr> <td>09:40</td> <td>The Carpentries: How We Operate </td> </tr>
-      <tr> <td>10:25</td> <td>Break </td> </tr>
-      <tr> <td>10:40</td> <td>Live Coding Is a Skill </td> </tr>
-      <tr> <td>11:45</td> <td>Preparing to Teach </td> </tr>
-      <tr> <td>12:30</td> <td>Finish day 3 </td> </tr>
-    </table>
-  </div>
-  <div class="col-md-6">
-    <h3>Day 4</h3>
-    <table class="table table-striped">
-      <tr> <td>13:30</td> <td>More Practice Live Coding </td> </tr>
-      <tr> <td>14:15</td> <td>Working with Your Team</td> </tr>
-      <tr> <td>15:25</td> <td>Break </td> </tr>
-      <tr> <td>15:40</td> <td>Launches and Landings </td> </tr>
-      <tr> <td>16:20</td> <td>Putting it Together </td> </tr>
-      <tr> <td>16:40</td> <td>Wraping Up </td> </tr>
-      <tr> <td>16:50</td> <td>Post-Training Survey </td> </tr>
-      <tr> <td>17:05</td> <td>Finish </td> </tr>
-    </table>
-  </div>
-</div>
-
--->
 
 ### Collaborative Notes
 Trainers will share the link to an [_Etherpad_](https://github.com/carpentries/community-engagement/blob/main/glossary.md#etherpad) that can be used for chatting, collaborating on notes, and sharing URLs and bits of code during the training.

--- a/learners/training_info.md
+++ b/learners/training_info.md
@@ -94,8 +94,8 @@ Please contact your Trainers using the details provided in the information email
 
 ## Training Materials and Schedule
 This website contains the curriculum for Instructor Training.
-Use the left sidebar to browse the content, and visit [the landing page in Instructor View](https://carpentries.github.io/instructor-training/instructor/index.html#schedule) for a sample schedule for a 2-day event.
-Note that many Instructor Training events take place over four half-days, and this schedule will not apply in those cases.
+Use the left sidebar to browse the content, and visit [the landing page in Instructor View](https://carpentries.github.io/instructor-training/instructor/index.html#schedule) for a sample schedule.
+Most Instructor Training events take place over four half-days, and the majority of others span two full days.
 
 ### Collaborative Notes
 Trainers will share the link to an [_Etherpad_](https://github.com/carpentries/community-engagement/blob/main/glossary.md#etherpad) that can be used for chatting, collaborating on notes, and sharing URLs and bits of code during the training.

--- a/learners/training_info.md
+++ b/learners/training_info.md
@@ -50,7 +50,7 @@ We do not require participants to provide documentation of disabilities or discl
 However, we do want to help create an inclusive, accessible experience for all participants.
 We encourage you to share any information that would be helpful to make your Carpentries experience accessible.
 To request an accommodation for this training, please fill out the [accommodation request form](https://carpentries.typeform.com/to/B2OSYaD0).
-If you have questions or need assistance with the accommodation form please [email us](mailto:team@carpentries.org).
+If you have questions or need assistance with the accommodation form please [email us](mailto:community@carpentries.org).
 
 For in-person training events, organisers have checked that:
 


### PR DESCRIPTION
(Tagging @carpentries/core-team-workshop-admin for review and discussion. Input also welcome from Trainers/others ❤️)

As discussed in previous Trainers meetings and internally with the Workshops and Instruction Team, this would replace the individual event websites that currently need to be built from https://github.com/carpentries/training-template.

You can preview what these changes look like at https://tobyhodges.github.io/solid-spoon/training_info.html

Some notes, relative to the current content in the training website template:

* Removes link to etherpad
* Assumes trainees will know who their Trainers will be, I guess from the initial info email they receive about the event (the one that links them to this page)?
* Removes the (commented out) suggested schedule table for a 4 half-day training. Maybe this should be added to the Instructor Notes for the curriculum?
* Presents info largely on the assumption that training will take place online via Zoom. I did include some notes about what would be different if the event takes place in-person, though.
* The page says, of the pre-training survey, that "You will receive a custom link for your event when you receive your connection information." Is this accurate? 