### PR TITLE
Configure Matomo analytics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,5 +109,6 @@ profiles:
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
 
-
+analytics: carpentries
 url: 'https://carpentries.github.io/instructor-training'
+lang: en


### PR DESCRIPTION
Sets up the curriculum site to be tracked by our self-hosted Matomo web analytics platform.