### PR TITLE
fix broken link

### DIFF
--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -316,7 +316,7 @@ Points to make during wrap-up:
 [demos]: https://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html#running-a-teaching-demonstration
 [etherpad-template]: https://pad.carpentries.org/ttt-template
 [training-template]: https://github.com/carpentries/training-template
-[minute-cards-template]: https://docs.google.com/forms/d/1p7iOV5HNvy4POS4g6eottY8RSfKq4kaoKz1-jIFYTMI/template/preview
+[minute-cards-template]: https://docs.google.com/forms/d/1lEdF1PuJB4FWhH8xLBDeQ9rwJRP304oBnkLv6DisM9o/edit
 [trainer-pad]: https://pad.carpentries.org/trainers
 [training-repo]: https://carpentries.github.io/instructor-training/
 [great-slide-issue]: https://github.com/carpentries/instructor-training/issues/680


### PR DESCRIPTION
Link to Minute Card templates went to a deleted file. 