### PR TITLE
update links to handbook throughout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       value: >
         Thank you for taking time to tell us about a problem in this repository.
-        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/policies/coc/)
         Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
         If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 
         please contact The Carpentries Team at team@carpentries.org.

--- a/.github/ISSUE_TEMPLATE/suggest_improvement_1_lesson.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_improvement_1_lesson.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       value: >
         Thank you for taking time to suggest an improvement to this repository.
-        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/policies/coc/).
         
         Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
         If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 

--- a/.github/ISSUE_TEMPLATE/suggest_improvement_2_episode.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_improvement_2_episode.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       value: >
         Thank you for taking time to suggest an improvement to this repository.
-        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/policies/coc/)
         
         Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
         If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ _If any relevant discussions have taken place elsewhere, please provide links to
 
 <details>
 
-For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/policies/coc/).
 
 Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,5 +9,5 @@ Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by following our [reporting guidelines][coc-reporting].
 
 
-[coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc-reporting]: https://docs.carpentries.org/policies/coc/incident-reporting.html
+[coc]: https://docs.carpentries.org/policies/coc/

--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -269,7 +269,7 @@ workshops specifically.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc]: https://docs.carpentries.org/policies/coc/
 [form-coc]: https://goo.gl/forms/KoUfO53Za3apOuOK2
 [lesson-dev-web]: https://carpentries.org/involved-lessons/
 [cldt]: https://carpentries.github.io/lesson-development-training/index.html

--- a/episodes/08-motivation.md
+++ b/episodes/08-motivation.md
@@ -134,7 +134,7 @@ confusion or doubt. Creating a motivating classroom means inviting communication
 A few ways to invite participation are:
 
 - **Establishing norms for interaction**. This can be done by creating procedures for communication, e.g. turn taking in discussions, passing around a 'talking
-  stick', or encouraging quieter people to contribute. Having, discussing, and enforcing a [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+  stick', or encouraging quieter people to contribute. Having, discussing, and enforcing a [Code of Conduct](https://docs.carpentries.org/policies/coc/)
   also provides a framework for positive communication to occur.
 - **Encouraging learners to learn from each other**. Working in pairs, or "[pair programming](https://en.wikipedia.org/wiki/Pair_programming)," encourages
   learners to talk through their learning process, reinforcing memory and making it more likely that confusion will be expressed and

--- a/episodes/09-eia.md
+++ b/episodes/09-eia.md
@@ -335,13 +335,13 @@ at the top), though our [\#accessibility channel][slack-accessibility] on [The C
 
 [glossary]: https://www.diversity.pitt.edu/education/glossary-terms
 [core-values]: https://carpentries.org/values/
-[handbook-host-template]: https://docs.carpentries.org/topic_folders/workshop_administration/email_templates.html#email-learners-before-workshop
+[handbook-host-template]: https://docs.carpentries.org/resources/workshops/email_templates.html
 [sketchplanations-curb-cuts]: https://sketchplanations.com/the-curb-cut-effect
 [CAST]: https://udlguidelines.cast.org
-[handbook-accessibility-checklist]: https://docs.carpentries.org/topic_folders/hosts_instructors/workshop_needs.html#accessibility
+[handbook-accessibility-checklist]: https://docs.carpentries.org/resources/workshops/workshop_needs.html#accessibility
 [post-surveys]: https://zenodo.org/record/1325464#.YVJIWS-B0ea
 [34gig]: https://ijoc.org/index.php/ijoc/article/view/1566
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc]: https://docs.carpentries.org/policies/coc/
 [slack-accessibility]: https://carpentries.slack.com/archives/CBDTKM30Q
 [slack-join]: https://slack-invite.carpentries.org
 

--- a/episodes/12-homework.md
+++ b/episodes/12-homework.md
@@ -26,7 +26,7 @@ look in some depth at how The Carpentries operates to prepare you for the logist
 
 To prepare for our next session, please:
 
-1. Read about [centrally-organized and self-organized workshops](https://carpentries.org/workshops/#workshop-organising) and our handbook content on [Teaching and Hosting Workshops](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html) -- be sure to click through to some of the associated checklists. These summarize commonly asked questions about organizing and running workshops.
+1. Read about [centrally-organized and self-organized workshops](https://carpentries.org/workshops/#workshop-organising) and our handbook content on [Teaching and Hosting Workshops](https://docs.carpentries.org/resources/workshops/) -- be sure to click through to some of the associated checklists. These summarize commonly asked questions about organizing and running workshops.
   When you arrive for the next part, we will ask you to add one question about our operations to a list.
   We will then do our best to answer all of those questions during the day.
 

--- a/episodes/14-checkout.md
+++ b/episodes/14-checkout.md
@@ -77,7 +77,7 @@ This exercise should take 5 minutes.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-[voting-rights]: https://docs.carpentries.org/topic_folders/governance/bylaws.html#eligibility-rights-and-termination-for-voting-members
+[voting-rights]: https://carpentries.org/about-us/governance/#carpentries-bylaws-and-policies
 [text-for-instructors]: https://github.com/carpentries/commons/blob/master/text-for-instructors.md
 
 

--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -193,7 +193,6 @@ The Carpentries Handbook is the definitive source for policies and information, 
 Carpentries-related activities. A few examples of useful content include:
 
 - template emails and checklists for Hosts, Instructors, and Helpers in [The Carpentries Handbook: Teaching and Hosting][docs-teach-host]
-- [policies][docs-policies], many of which affect Instructors and workshops, including
 - the [instructor no-show policy][docs-noshow] which is important to read before signing up for your first workshop
 
 As The Carpentries grows and changes in response to a complex global legal landscape, our policies and procedures are likely to change. Be sure to check
@@ -331,21 +330,20 @@ This exercise should take about 5 minutes.
 [LIBERQ]: https://doi.org/10.18352/lq.10176
 [values-page]: https://carpentries.org/values/
 [workshopsreq-page]: https://carpentries.org/workshops/#workshop-core
-[docs-workshop-checklists]: https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html
+[docs-workshop-checklists]: https://docs.carpentries.org/resources/workshops/checklists.html
 [workshops-form]: https://amy.carpentries.org/forms/workshop/
 [workshops-page]: https://carpentries.org/workshops/#workshop-organising
 [membership-page]: https://carpentries.org/membership/
 [SO-recruiting-blog]: https://carpentries.org/blog/2021/06/Recruiting-Instructors-for-Self-Organised-Workshops/
 [docs]: https://docs.carpentries.org/
-[docs-teach-host]: https://docs.carpentries.org/topic_folders/hosts_instructors/index.html
-[docs-policies]: https://docs.carpentries.org/topic_folders/policies/index.html
-[docs-noshow]: https://docs.carpentries.org/topic_folders/policies/instructor-no-show-policy.html#instructor-no-show-policy
+[docs-teach-host]: https://docs.carpentries.org/resources/workshops/
+[docs-noshow]: https://docs.carpentries.org/handbooks/instructors.html#instructor-training-attendance-policy
 [connect-page]: https://carpentries.org/connect/
 [instructors-list]: https://carpentries.topicbox.com/groups/instructors
 [carpentries-incubator]: https://github.com/carpentries-incubator/proposals/
 [template-md]: https://github.com/carpentries/workbench-template-md/
 [template-rmd]: https://github.com/carpentries/workbench-template-rmd/
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#code-of-conduct-summary-view
+[coc]: https://docs.carpentries.org/policies/coc/
 [cc-by]: https://creativecommons.org/licenses/by/4.0/
 [cc-0]: https://creativecommons.org/share-your-work/public-domain/cc0/
 [cld]: https://carpentries.github.io/lesson-development-training

--- a/episodes/21-management.md
+++ b/episodes/21-management.md
@@ -266,9 +266,9 @@ We encourage you to **discuss an approach to managing Code of Conduct violations
 
 ## Know Your Resources
 
-1) Take 5 minutes to read through the Code of Conduct Incident Response Guidelines: [https://docs.carpentries.org/topic\_folders/policies/incident-response.html](https://docs.carpentries.org/topic_folders/policies/incident-response.html)
+1) Take 5 minutes to read through the Code of Conduct Incident Response Guidelines: [https://docs.carpentries.org/policies/coc/incident-response.html](https://docs.carpentries.org/policies/coc/incident-response.html)
 2) Discuss what you have read in small groups. As questions arise, you may wish to refer to our complete Code of Conduct section in The Carpentries Handbook:
-  [https://docs.carpentries.org/topic\_folders/policies/index\_coc.html](https://docs.carpentries.org/topic_folders/policies/index_coc.html) or to the Transparency Reports released by The Carpentries Code of Conduct Committee: [https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports](https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports)
+  [https://docs.carpentries.org/policies/coc/](https://docs.carpentries.org/policies/coc/) or to the Transparency Reports released by The Carpentries Code of Conduct Committee: [https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports](https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports)
 
 - What kinds of things could your instructional team agree upon in advance of your workshop?
 - What questions do you have about CoC enforcement?
@@ -440,10 +440,10 @@ Note that there are pros and cons to using Etherpad. Pads do occasionally
 freeze or crash, so we recommend creating a backup copy. Otherwise, Etherpads persist
 indefinitely, so they may be used for further reference after a workshop.
 
-[host-checklist]: https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#host-checklist
+[host-checklist]: https://docs.carpentries.org/resources/workshops/checklists.html#host-checklist
 [worldcat-interactions]: https://www.worldcat.org/title/interactions-collaboration-skills-for-school-professionals/oclc/930364264
-[helpers]: https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist
-[CoC-summary]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#code-of-conduct-summary-view
+[helpers]: https://docs.carpentries.org/resources/workshops/checklists.html#helper-checklist
+[CoC-summary]: https://docs.carpentries.org/policies/coc/#code-of-conduct-summary-view
 [vps]: https://en.wikipedia.org/wiki/Virtual_private_server
 [ssh]: https://en.wikipedia.org/wiki/Secure_Shell
 [blog-coc-facilitators]: https://carpentries.org/blog/2021/06/code-of-conduct-facilitators-module/

--- a/episodes/23-introductions.md
+++ b/episodes/23-introductions.md
@@ -171,7 +171,7 @@ additional requests as needed.
 
 **Communicate your expectations** for learners, including:
 
-- how to follow the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/index_coc.html)
+- how to follow the [Code of Conduct](https://docs.carpentries.org/policies/coc/)
 - ways to ask for help
 - ways to give feedback to the instructional team
 

--- a/index.md
+++ b/index.md
@@ -54,7 +54,7 @@ Feedback on these materials is welcome as an [issue][issues] on the GitHub repos
 
 **These materials are freely available under a [Creative Commons license][license].**
 
-[conduct]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[conduct]: https://docs.carpentries.org/policies/coc/
 [issues]: https://github.com/carpentries/instructor-training/issues
 [license]: LICENSE.html
 [cldt-curriculum]: https://carpentries.github.io/lesson-development-training/index.html

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -312,8 +312,8 @@ Points to make during wrap-up:
 - Thank you for your excellent feedback! Instructors like you help to make this community what it is.
 - I will follow up with each of you by email within \_\_\_ (time period). If you do not hear from me by \_\_ feel free to check in.
 
-[handbook]: https://docs.carpentries.org/topic_folders/instructor_training/index.html#for-trainers
-[demos]: https://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html#running-a-teaching-demonstration
+[handbook]: https://docs.carpentries.org/handbooks/instructor_trainers.html
+[demos]: https://docs.carpentries.org/handbooks/instructor_trainers.html#teaching-demonstrations
 [etherpad-template]: https://pad.carpentries.org/ttt-template
 [training-template]: https://github.com/carpentries/training-template
 [minute-cards-template]: https://docs.google.com/forms/d/1lEdF1PuJB4FWhH8xLBDeQ9rwJRP304oBnkLv6DisM9o/edit

--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -3,7 +3,7 @@ title: Checkout Instructions
 calendar: https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com
 demopad: https://pad.carpentries.org/teaching-demos
 discussionpad: https://pad.carpentries.org/community-discussions
-discussioninfo: https://docs.carpentries.org/topic_folders/instructor_development/community_discussions.html
+discussioninfo: https://docs.carpentries.org/handbooks/community_session_host.html
 ---
 
 ## Instructor Checkout
@@ -350,7 +350,7 @@ Approximately 1-2 weeks after your last step is complete, you should receive an 
 [help-wanted]: https://carpentries.org/help-wanted-issues/
 [github-guide]: https://github.com/carpentries-incubator/swc_github_flow/blob/master/for_novice_contributors.md
 [contributing]: https://github.com/carpentries/instructor-training/blob/main/CONTRIBUTING.md
-[handbook-amy]: https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#accessing-and-updating-your-instructor-profile
+[handbook-amy]: https://carpentries.github.io/amy/users_guide/community_index/#user-profiles
 [git-blog]: https://carpentries.org/blog/2020/05/2020-05-04-conversations-teaching-git-github/
 [contact-page]: https://carpentries.org/contact/
 [carpentries-incubator]: https://github.com/carpentries-incubator/

--- a/learners/training_calendar.md
+++ b/learners/training_calendar.md
@@ -34,7 +34,7 @@ Trainees who miss more than 1 hour of an Instructor Training event may be marked
 
 A link is provided next to each event that will convert the start time to your local time zone. Please be sure to verify your availability for the full instructional time of your event. If you expect to miss more than a total of 1 hour, please select a different event.
 
-More details on our [cancellation and makeup policy](https://docs.carpentries.org/topic_folders/instructor_training/cancellations_and_makeups.html) are available in The Carpentries Handbook.
+More details on our [cancellation and makeup policy](https://docs.carpentries.org/handbooks/instructors.html#instructor-training-attendance-policy) are available in The Carpentries Handbook.
 
 ### Upcoming Instructor Training
 

--- a/registration_confirmation.md
+++ b/registration_confirmation.md
@@ -40,7 +40,7 @@ After a registration has been cancelled in Eventbrite, the code that was used to
 
 If a trainee repeatedly registers and cancels (more than 3 times), or registers for more than one seat at the same time, they may be barred from further registration.
 
-More details on our [cancellation and makeup policy](https://docs.carpentries.org/topic_folders/instructor_training/cancellations_and_makeups.html) are available in The Carpentries Handbook.
+More details on our [cancellation and makeup policy](https://docs.carpentries.org/handbooks/instructors.html#instructor-training-attendance-policy) are available in The Carpentries Handbook.
 
 ## Learn More and Get Connected
 


### PR DESCRIPTION
Now that we have a redesigned [handbook](https://docs.carpentries.org/), this updates links throughout the IT curriculum.  

