### PR TITLE
Improve link display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 episodes/*html
 site/*
 !site/README.md
-
 # History files
 .Rhistory
 .Rapp.history
@@ -10,6 +9,8 @@ site/*
 .RData
 # User-specific files
 .Ruserdata
+# Project files
+.Rproj
 # Example code in package build process
 *-Ex.R
 # Output files from R CMD build
@@ -53,3 +54,4 @@ vendor/
 .docker-vendor/
 Gemfile.lock
 .*history
+instructor-training.Rproj

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ site/*
 # User-specific files
 .Ruserdata
 # Project files
-.Rproj
+*.Rproj
 # Example code in package build process
 *-Ex.R
 # Output files from R CMD build

--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -135,7 +135,7 @@ Now, we would like to get to know all of you.
 For the multiple choice questions below, please place an "X" next to the response(s) that best apply to you. Then find yourself a spot
 in the Etherpad below to write a short response to the last question.
 
-*Have you ever participated in a Software Carpentry, Data Carpentry, or Library Carpentry Workshop?*
+**Have you ever participated in a Software Carpentry, Data Carpentry, or Library Carpentry Workshop?**
 
 1. Yes, I have taken a workshop.
 2. Yes, I have been a workshop helper.
@@ -143,7 +143,8 @@ in the Etherpad below to write a short response to the last question.
 4. No, but I am familiar with what is taught at a workshop.
 5. No, and I am not familiar with what is taught at a workshop.
 
-*Which of these most accurately describes your teaching experience?*
+
+**Which of these most accurately describes your teaching experience?**
 
 1. I have been a graduate or undergraduate teaching assistant for a university/college course.
 2. I have not had any teaching experience in the past.
@@ -151,6 +152,7 @@ in the Etherpad below to write a short response to the last question.
 4. I have been the primary or responsible teacher for a university/college course.
 5. I have taught at the primary or secondary education level.
 6. I have taught informally through outreach programs, hackathons, libraries, laboratory demonstrations, and similar activities.
+
 
 **Why are you taking this course? What goals do you have for this training?**
 
@@ -195,7 +197,7 @@ These four goals are broken down into four main themes of content:
 
 ### How Learning Works
 
-One of our main emphases will be discussing the "best practices" of teaching. We
+One of our main emphases will be discussing the **best practices** of teaching. We
 will be introducing you to a handful of key educational research
 findings and demonstrating how they can be used to help people learn better and faster.
 

--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -122,8 +122,7 @@ instructor training.  We are very pleased to have you with us.
 
 To begin class, each Trainer should give a brief introduction of themselves.
 
-(For some guidelines on introducing yourself, see some content from
-later in the training: [Introductions](23-introductions.md))
+(For some guidelines on introducing yourself, see some content from the [Introductions section](23-introductions.md) later in the training: )
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -173,10 +172,8 @@ The Carpentries is a **global community of volunteer researchers, educators, and
 improving basic computing and data skills for
 researchers through intensive, short-format workshops.
 
-- Software Carpentry focuses on helping researchers develop foundational
-  computational skills
-- Data Carpentry focuses on helping
-  researchers work effectively with their data through its lifecycle
+- Software Carpentry focuses on helping researchers develop foundational computational skills
+- Data Carpentry focuses on helping researchers work effectively with their data through its lifecycle
 - Library Carpentry focuses on teaching data skills to people working in library- and information-related roles.
 
 The main goal of The Carpentries is not to teach specific skills, per se - although those
@@ -189,14 +186,10 @@ The goal of this training is to provide you with the skills and information you 
 to become a certified Carpentries Instructor. Our expectations of certified
 Instructors is that they:
 
-- be familiar with and understand **how to apply research-based teaching principles**,
-  especially as they apply to The Carpentries audience.
-- understand the **importance of a respectful and inclusive classroom environment**; commit to
-  creating such an environment; and be able to
-  identify and implement The Carpentries policies and general practices to accomplish this.
+- be familiar with and understand **how to apply research-based teaching principles**, especially as they apply to The Carpentries audience.
+- understand the **importance of a respectful and inclusive classroom environment**; commit to creating such an environment; and be able to identify and implement The Carpentries policies and general practices to accomplish this.
 - **practice and develop skills** in the teaching methods used in The Carpentries workshops.
-- learn enough about The Carpentries organisation to **know where to go for help**,
-  how to start organizing a workshop, and how to get involved with community activities.
+- learn enough about The Carpentries organisation to **know where to go for help**, how to start organizing a workshop, and how to get involved with community activities.
 
 These four goals are broken down into four main themes of content:
 

--- a/episodes/02-practice-learning.md
+++ b/episodes/02-practice-learning.md
@@ -5,317 +5,389 @@ teaching: 30
 exercises: 30
 ---
 
-::::::::::::::::::::::::::::::::::::::: objectives
+::: objectives
+-   Compare and contrast the three stages of skill acquisition.
+-   Identify a mental model and an analogy that can help to explain it.
+-   Apply a concept map to explore a simple mental model.
+-   Understand the limitations of knowledge in the absence of a
+    functional mental model.
+-   Create a formative assessment to diagnose a broken mental model.
+:::
 
-- Compare and contrast the three stages of skill acquisition.
-- Identify a mental model and an analogy that can help to explain it.
-- Apply a concept map to explore a simple mental model.
-- Understand the limitations of knowledge in the absence of a functional mental model.
-- Create a formative assessment to diagnose a broken mental model.
+::: questions
+-   How do people learn?
+-   Who is a typical Carpentries learner?
+-   How can we help novices become competent practitioners?
+:::
 
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::::::::::::::::::::::::::: questions
-
-- How do people learn?
-- Who is a typical Carpentries learner?
-- How can we help novices become competent practitioners?
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-We will now get started with a discussion of how learning works. We will begin with
-some key concepts from educational research and identify how these principles
-are put into practice in Carpentries workshops.
+We will now get started with a discussion of how learning works. We will
+begin with some key concepts from educational research and identify how
+these principles are put into practice in Carpentries workshops.
 
 ## The Carpentries Pedagogical Model
 
-The Carpentries aims to teach computational competence to learners. We take an applied approach, avoiding the theoretical and general
-in favor of the practical and specific. By showing learners how to solve specific problems with specific tools and providing hands-on
-practice, we develop learners' confidence and lay the foundation for future learning.
+The Carpentries aims to teach computational competence to learners. We
+take an applied approach, avoiding the theoretical and general in favor
+of the practical and specific. By showing learners how to solve specific
+problems with specific tools and providing hands-on practice, we develop
+learners' confidence and lay the foundation for future learning.
 
-A critical component of this process is that learners are able to practice what they are learning in real time, get
-feedback on what they are doing, and then apply those lessons learned to the next step in the learning process. Having
-learners help each other during the workshops also helps to reinforce concepts taught during the workshops.
+A critical component of this process is that learners are able to
+practice what they are learning in real time, get feedback on what they
+are doing, and then apply those lessons learned to the next step in the
+learning process. Having learners help each other during the workshops
+also helps to reinforce concepts taught during the workshops.
 
-**A Carpentries workshop is an interactive event** -- for learners and instructors. We give and
-receive feedback throughout the course of a workshop. We incorporate assessments within the lesson materials and
-ask for feedback on sticky notes during lunch breaks and at the end of each day.
+**A Carpentries workshop is an interactive event** -- for learners and
+instructors. We give and receive feedback throughout the course of a
+workshop. We incorporate assessments within the lesson materials and ask
+for feedback on sticky notes during lunch breaks and at the end of each
+day.
 
-One reason why practice and feedback are so important is because a Carpentries workshop is not simply a source of information;
-it is the starting point for development of a new skill. To understand what this means, we will start by exploring what
-research tells us about skill acquisition and development of a "mental model."
+One reason why practice and feedback are so important is because a
+Carpentries workshop is not simply a source of information; it is the
+starting point for development of a new skill. To understand what this
+means, we will start by exploring what research tells us about skill
+acquisition and development of a "mental model."
 
 ## The Acquisition of Skill
 
 Our approach is based on the work of researchers like Patricia Benner,
-who applied the [Dreyfus model of skill acquisition][wikipedia-dreyfus-skill]
-in her studies of
-[how nurses progress from novice to expert][nurses-dreyfus]
-([see also books by Benner][Benner-dreyfus]). This work indicates that
-through practice and formal instruction, learners acquire skills and advance through distinct stages. In simplified form, three stages of this model are:
+who applied the [Dreyfus model of skill
+acquisition](https://en.wikipedia.org/wiki/Dreyfus_model_of_skill_acquisition)
+in her studies of [how nurses progress from novice to
+expert](https://journals.sagepub.com/doi/10.1177/0270467604265061) ([see
+also books by
+Benner](https://www.worldcat.org/search?q=au%3ABenner%2C+Patricia+E.)).
+This work indicates that through practice and formal instruction,
+learners acquire skills and advance through distinct stages. In
+simplified form, three stages of this model are:
 
-![](fig/skill-level.svg){alt='Three people, labeled from left to right as "Novice", "Competent Practitioner", and "Expert". Underneath,an arrow labelled "Experience level" points from left to right. The "Novice" is quoted, "I am not sure what questions to ask." The Competent Practitioner is quoted, "I am pretty confident, but I still look stuff up a lot!" The Expert is quoted "I have been doing this on a daily basis for years!"'}
+![](fig/skill-level.svg){alt="Three people, labeled from left to right as \"Novice\", \"Competent Practitioner\", and \"Expert\". Underneath,an arrow labelled \"Experience level\" points from left to right. The \"Novice\" is quoted, \"I am not sure what questions to ask.\" The Competent Practitioner is quoted, \"I am pretty confident, but I still look stuff up a lot!\" The Expert is quoted \"I have been doing this on a daily basis for years!\""}
 
-- *Novice*: someone who does not know what they do not know, i.e.,
-  they do not yet know what the key ideas in the domain are or how they relate.
-  Novices may have difficulty formulating questions, or may ask questions that seem irrelevant or off-topic
-  as they rely on prior knowledge, without knowing what is or is not related yet.
-  
-  > Example: A *novice* learner in a Carpentries workshop might never have heard of the bash shell, and therefore
-  > may have no understanding of how it relates to their file system or other programs on their computer.
+-   *Novice*: someone who does not know what they do not know, i.e.,
+    they do not yet know what the key ideas in the domain are or how
+    they relate. Novices may have difficulty formulating questions, or
+    may ask questions that seem irrelevant or off-topic as they rely on
+    prior knowledge, without knowing what is or is not related yet.
 
-- *Competent practitioner*: someone who has enough understanding for everyday purposes. They will not know all the details
-  of how something works and their understanding may not be entirely accurate, but it is sufficient for completing normal
-  tasks with normal effort under normal circumstances.
-  
-  > Example: A *competent practitioner* in a Carpentries workshop might have used the shell before and understand how to
-  > move around directories and use individual programs, but they might not understand how they can fit these programs
-  > together to build scripts and automate large tasks.
+    > Example: A *novice* learner in a Carpentries workshop might never have heard of the bash shell, and therefore may have no understanding of how it relates to their file system or other programs on their computer.
 
-- *Expert*: someone who can easily handle situations that are out of the ordinary.
-  
-  > Example: An *expert* in a Carpentries workshop may have experience writing and running shell scripts and, when
-  > presented with a problem, immediately sees how these skills can be used to solve the problem.
+-   *Competent practitioner*: someone who has enough understanding for
+    everyday purposes. They will not know all the details of how
+    something works and their understanding may not be entirely
+    accurate, but it is sufficient for completing normal tasks with
+    normal effort under normal circumstances.
 
-Note that how a person *feels* about their skill level is not included in these definitions! You may or may not
-consider yourself an expert in a particular subject, but may nonetheless function at that level in certain contexts.
-We will come back to the expertise of the Instructor and its impact -- positive and negative --
-on teaching, in the next episode.
-For now, we are primarily concerned with novices,
-as this is The Carpentries' primary target audience.
+    > Example: A *competent practitioner* in a Carpentries workshop might have used the shell before and understand how to move around directories and use individual programs, but they might not understand how they can fit these programs together to build scripts and automate large tasks.
 
-It is common to think of a novice as a sort of an "empty vessel" into which knowledge can be "poured." Unfortunately, this analogy includes inaccuracies that can generate dangerous misconceptions. In our next section, we will briefly explore
-the nature of "knowledge" through a concept
-that helps us differentiate between novices and competent practitioners in a more useful and visual way. This, in turn, will have implications
-for how we teach.
+-   *Expert*: someone who can easily handle situations that are out of the ordinary.
+
+    > Example: An *expert* in a Carpentries workshop may have experience writing and running shell scripts and, when presented with a problem, immediately sees how these skills can be used to solve the problem.
+
+Note that how a person *feels* about their skill level is not included
+in these definitions! You may or may not consider yourself an expert in
+a particular subject, but may nonetheless function at that level in
+certain contexts. We will come back to the expertise of the Instructor
+and its impact -- positive and negative -- on teaching, in the next
+episode. For now, we are primarily concerned with novices, as this is
+The Carpentries' primary target audience.
+
+It is common to think of a novice as a sort of an "empty vessel" into
+which knowledge can be "poured." Unfortunately, this analogy includes
+inaccuracies that can generate dangerous misconceptions. In our next
+section, we will briefly explore the nature of "knowledge" through a
+concept that helps us differentiate between novices and competent
+practitioners in a more useful and visual way. This, in turn, will have
+implications for how we teach.
 
 ## Building a Mental Model
 
-:::::::::::::::::::::::::::::::::::::  callout
-
+::: callout
 ### Models are not perfect but are still helpful
 
 All models are wrong, but some are useful.
 
-- George Box, statistician
-  
+-   George Box, statistician
+:::
 
-::::::::::::::::::::::::::::::::::::::::::::::::::
+Understanding is never a mirror of reality, even for an expert; rather,
+it is an internal representation based on our experience with a subject.
+This internal representation is often described as a **mental model**. A
+mental model allows us to extrapolate, or make predictions beyond and
+between the narrow limits of experience and memory, filling in gaps to
+the point that things "make sense."
 
-Understanding is never a mirror of reality, even for an expert; rather, it is
-an internal representation based on our experience with a subject.
-This internal representation is often described as a **mental model**. A mental model
-allows us to extrapolate, or make predictions beyond and between the narrow limits of experience and memory, filling in
-gaps to the point that things "make sense."
-
-As we learn, our mental model evolves to become more complex and, most importantly, more useful. A useful model makes reasonable predictions and fits well within
-the range of things
-we are likely to encounter. While there will always be inaccuracies -- or "misconceptions" -- these do not interfere with day-to-day functioning.
-A useful model does not seize up or break down entirely as new concepts are added.
+As we learn, our mental model evolves to become more complex and, most
+importantly, more useful. A useful model makes reasonable predictions
+and fits well within the range of things we are likely to encounter.
+While there will always be inaccuracies -- or "misconceptions" -- these
+do not interfere with day-to-day functioning. A useful model does not
+seize up or break down entirely as new concepts are added.
 
 ### The power (and limitations) of analogies
 
-Some mental models can be succinctly summarized by comparison to something else that is more universally understood.  Good analogies can be extraordinarily useful when teaching,
-because they draw upon an existing mental model to fill in another, speeding learning and making a memorable connection. However, all analogies have limitations!
-If you choose to use an analogy, be sure its usefulness outweighs its potential to generate misconceptions that may interfere with learning.
+Some mental models can be succinctly summarized by comparison to
+something else that is more universally understood. Good analogies can
+be extraordinarily useful when teaching, because they draw upon an
+existing mental model to fill in another, speeding learning and making a
+memorable connection. However, all analogies have limitations! If you
+choose to use an analogy, be sure its usefulness outweighs its potential
+to generate misconceptions that may interfere with learning.
 
-:::::::::::::::::::::::::::::::::::::::  challenge
-
+::: challenge
 ## Analogy Brainstorm
 
-1. Think of an analogy to explore. Perhaps you have a favorite that relates to your area of professional interest, or a hobby. If
-  you prefer to work with an example, consider this analogy from education: "teaching is like gardening."
-2. Share your analogy with a partner or group. (If you have not yet done so, be sure to take a moment to introduce yourself, first!) What does your analogy
-  convey about the topic? How is it useful? In what ways is it wrong?
+1.  Think of an analogy to explore. Perhaps you have a favorite that
+    relates to your area of professional interest, or a hobby. If you
+    prefer to work with an example, consider this analogy from
+    education: "teaching is like gardening."
+2.  Share your analogy with a partner or group. (If you have not yet
+    done so, be sure to take a moment to introduce yourself, first!)
+    What does your analogy convey about the topic? How is it useful? In
+    what ways is it wrong?
 
 This activity should take about 10 minutes.
+:::
 
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::::::::::::::::::::::::::::  callout
-
+::: callout
 ## Analogies at Work: "Software Carpentry"
 
 People often ask where our name came from. Greg Wilson has this to say:
 
-"Brent Gorda and I came up with the name in 1998 to differentiate what we were teaching from software engineering. That's about digging the Channel Tunnel;
-we're about the computational equivalent of hanging drywall."
+"Brent Gorda and I came up with the name in 1998 to differentiate what
+we were teaching from software engineering. That's about digging the
+Channel Tunnel; we're about the computational equivalent of hanging
+drywall."
 
-The word "carpentry" acts as a metaphor -- a type of analogy -- inspiring a comparison with something concrete,
-hands on, practical, and useful. This clearly conveys the purpose of our organization: to support computational skill development
-among working practitioners who need the right tools and practices to be effective day to day.
+The word "carpentry" acts as a metaphor -- a type of analogy --
+inspiring a comparison with something concrete, hands on, practical, and
+useful. This clearly conveys the purpose of our organization: to support
+computational skill development among working practitioners who need the
+right tools and practices to be effective day to day.
+:::
 
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-A mental model may be represented as a collection of concepts and facts, connected by relationships.
-The mental model of an expert in any given subject will be far larger and more complex than that of a novice, including both more concepts
-and more detailed and numerous relationships. However, **both may be perfectly useful** in certain contexts.
+A mental model may be represented as a collection of concepts and facts,
+connected by relationships. The mental model of an expert in any given
+subject will be far larger and more complex than that of a novice,
+including both more concepts and more detailed and numerous
+relationships. However, **both may be perfectly useful** in certain
+contexts.
 
 Returning to our example levels of skill development:
 
-- A *novice* has a minimal mental model of surface features of the domain. Inaccuracies based on limited prior knowledge may interfere with adding new information.
-  Predictions are likely to borrow heavily from mental models of other domains
-  which seem superficially similar.
-- A *competent practitioner* has a mental model that is useful for everyday purposes. Most new information
-  they are likely to encounter will fit well with their existing model. Even though many potential elements of their mental model may
-  still be missing or wrong, predictions about their area of work are usually accurate.
-- An *expert* has a densely populated and connected mental model that is especially good for problem solving.
-  They quickly connect concepts that others may not see as being related. They may have difficulty
-  explaining how they are thinking in ways that do not rely on other features unique to their own mental model.
+-   A *novice* has a minimal mental model of surface features of the
+    domain. Inaccuracies based on limited prior knowledge may interfere
+    with adding new information. Predictions are likely to borrow
+    heavily from mental models of other domains which seem superficially
+    similar.
+-   A *competent practitioner* has a mental model that is useful for
+    everyday purposes. Most new information they are likely to encounter
+    will fit well with their existing model. Even though many potential
+    elements of their mental model may still be missing or wrong,
+    predictions about their area of work are usually accurate.
+-   An *expert* has a densely populated and connected mental model that
+    is especially good for problem solving. They quickly connect
+    concepts that others may not see as being related. They may have
+    difficulty explaining how they are thinking in ways that do not rely
+    on other features unique to their own mental model.
 
-![](fig/mental_models.svg){alt='Three collections of six circles. The first collection is labelled "Novice" and has only two arrows connecting some of the circles. The second collection, labelled "Competent Practitioner" has six connecting arrows. The third collection, labelled "Expert", is densly connected, with eight connecting arrows.'}
+![](fig/mental_models.svg){alt="Three collections of six circles. The first collection is labelled \"Novice\" and has only two arrows connecting some of the circles. The second collection, labelled \"Competent Practitioner\" has six connecting arrows. The third collection, labelled \"Expert\", is densly connected, with eight connecting arrows."}
 
 ### Mapping a Mental Model
-:::::::::::::::::::::::::::::::::::::::  instructor
-People often request to see more examples of concept maps. These are some examples linked from a previous version of the curriculum:
 
-- [Array Math](fig/array-math.png)
-- [Conditionals](fig/conditionals.png)
-- [Creating and Destroying Files](fig/create-destroy.png)
-- [Sets and Dictionaries in Python](fig/dict-set.png)
-- [Input and Output](fig/io.png)
-- [Lists and Loops](fig/lists-loops.png)
-- [Git Version Control](fig/git_concept_map.png)
+::: instructor
+People often request to see more examples of concept maps. These are
+some examples linked from a previous version of the curriculum:
 
-Most of these are much larger than our recommended limit for the activity. It can be helpful to make a larger map and then narrow down to a smaller one.
+-   [Array Math](fig/array-math.png)
+-   [Conditionals](fig/conditionals.png)
+-   [Creating and Destroying Files](fig/create-destroy.png)
+-   [Sets and Dictionaries in Python](fig/dict-set.png)
+-   [Input and Output](fig/io.png)
+-   [Lists and Loops](fig/lists-loops.png)
+-   [Git Version Control](fig/git_concept_map.png)
 
-::::::::::::::::::::::::::::::::::::::::::::::::::
+Most of these are much larger than our recommended limit for the
+activity. It can be helpful to make a larger map and then narrow down to
+a smaller one.
+:::
 
-Most people do not naturally visualize a mental model as a diagram of concepts and relationships. Mental models are complicated!
-Yet, visual representation of concepts and relationships can be a useful way to explore and understand hidden features of a mental model.
+Most people do not naturally visualize a mental model as a diagram of
+concepts and relationships. Mental models are complicated! Yet, visual
+representation of concepts and relationships can be a useful way to
+explore and understand hidden features of a mental model.
 
-There are certain ways in which you may routinely use visual organizers, such as
-flow charts or biochemical pathway diagrams. A more general tool that is useful for exploring any network of concepts and relationships is a **concept map**. Pioneered for
-classroom use by John Novak in the 1970s, a concept map asks you to identify which concepts are most relevant to a topic at hand and -- critically -- to
-identify how they are connected. It can be quite difficult to identify and organize these connections! However, the process of forcing abstract knowledge into a visual
-format can force you to name connections that you might otherwise have quietly assumed, or illuminate gaps that you may not have been aware of. Especially where analogies are not available, concept mapping can help
-you to make your mental model of a concept more clear to yourself or others.
+There are certain ways in which you may routinely use visual organizers,
+such as flow charts or biochemical pathway diagrams. A more general tool
+that is useful for exploring any network of concepts and relationships
+is a **concept map**. Pioneered for classroom use by John Novak in the
+1970s, a concept map asks you to identify which concepts are most
+relevant to a topic at hand and -- critically -- to identify how they
+are connected. It can be quite difficult to identify and organize these
+connections! However, the process of forcing abstract knowledge into a
+visual format can force you to name connections that you might otherwise
+have quietly assumed, or illuminate gaps that you may not have been
+aware of. Especially where analogies are not available, concept mapping
+can help you to make your mental model of a concept more clear to
+yourself or others.
 
-As an example, consider a mental model of the relationship between a small ball and water in a full glass.
+As an example, consider a mental model of the relationship between a
+small ball and water in a full glass.
 
-The concept map below illustrates a simple mental model that a young child might develop after putting the ball in the water.
+The concept map below illustrates a simple mental model that a young
+child might develop after putting the ball in the water.
 
-![](fig/ballwater1a.svg){alt='Two words inside rectangles, with labeled arrows connecting them. "Ball" is at the left, with an arrow pointing to "Water", at right, labeled as "Pushes out."'}
+![](fig/ballwater1a.svg){alt="Two words inside rectangles, with labeled arrows connecting them. \"Ball\" is at the left, with an arrow pointing to \"Water\", at right, labeled as \"Pushes out.\""}
 
-Give a child balls of three different sizes, and they might put together a somewhat more complex mental model,
-perhaps illustrated as:
+Give a child balls of three different sizes, and they might put together
+a somewhat more complex mental model, perhaps illustrated as:
 
-![](fig/ballwater2a.svg){alt='Four words inside rectangles, with labeled arrows connecting them. "Ball" is at the left, and "Water", at right. "Big Ball" and "Small Ball" are stacked vertically between them. Arrows from "Ball" are labeled "can be MORE" and can be "LESS", and arrows to "water" are labeled as "Pushes out MORE" and "Pushes out "LESS"'}
+![](fig/ballwater2a.svg){alt="Four words inside rectangles, with labeled arrows connecting them. \"Ball\" is at the left, and \"Water\", at right. \"Big Ball\" and \"Small Ball\" are stacked vertically between them. Arrows from \"Ball\" are labeled \"can be MORE\" and can be \"LESS\", and arrows to \"water\" are labeled as \"Pushes out MORE\" and \"Pushes out \"LESS\""}
 
-:::::::::::::::::::::::::::::::::::::::  challenge
-
+::: challenge
 ## Mapping a Mental Model
 
-1) On a piece of paper, draw a simplified concept map of the same concept you discussed in the last activity, but this time without the analogy.
-  What are 3-4 core
-  concepts involved? How are those concepts related? (Note: if you would like to try out an online tool for this exercise, visit [Exclidraw](https://excalidraw.com) [https://excalidraw.com](https://excalidraw.com).)
+1)  On a piece of paper, draw a simplified concept map of the same
+    concept you discussed in the last activity, but this time without
+    the analogy. What are 3-4 core concepts involved? How are those
+    concepts related? (Note: if you would like to try out an online tool
+    for this exercise, visit [Excalidraw](https://excalidraw.com) at [https://excalidraw.com](https://excalidraw.com).)
 
-2) In the Etherpad, write some notes on this process. Was it difficult? Do you think it would be a useful exercise prior to teaching about your topic?
-  What challenges might a novice face in creating a concept map of this kind?  
-  This exercise should take about 5 minutes.
-  
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
+2)  In the Etherpad, write some notes on this process. Was it difficult?
+    Do you think it would be a useful exercise prior to teaching about
+    your topic? What challenges might a novice face in creating a
+    concept map of this kind?
+    This exercise should take about 5 minutes.
+:::
 
 ## Misconceptions
 
-The mental model above connects a ball to the water it can displace, recognizing that 'more' ball can move 'more' water. This mental model is perfectly functional for a child who wants to have fun splashing water around.
-It may endure in this way for several years of beaches and bathtubs.
+The mental model above connects a ball to the water it can displace,
+recognizing that 'more' ball can move 'more' water. This mental model is
+perfectly functional for a child who wants to have fun splashing water
+around. It may endure in this way for several years of beaches and
+bathtubs.
 
-However, when this child is asked to predict what would happen to the water if a ball were not bigger or smaller but *heavier* or *lighter*, they will naturally apply their existing mental model to the task.
+However, when this child is asked to predict what would happen to the
+water if a ball were not bigger or smaller but *heavier* or *lighter*,
+they will naturally apply their existing mental model to the task.
 BUT...
 
-![](fig/ballwater3a.svg){alt='A concept map similar to the previous one except with "Heavy Ball" and "Light Ball" in the middle, and a red "X" over the arrows labeled "Pushes out MORE" and "Pushes out LESS"'}
+![](fig/ballwater3a.svg){alt="A concept map similar to the previous one except with \"Heavy Ball\" and \"Light Ball\" in the middle, and a red \"X\" over the arrows labeled \"Pushes out MORE\" and \"Pushes out LESS\""}
 
-What a surprise! The challenge presented by this new information is that it clashes with the pre-existing mental model, to which it seemed to apply. This prior knowledge needs to be adjusted to a new understanding that incorporates the difference between properties of mass and volume.
+What a surprise! The challenge presented by this new information is that
+it clashes with the pre-existing mental model, to which it seemed to
+apply. This prior knowledge needs to be adjusted to a new understanding
+that incorporates the difference between properties of mass and volume.
 
-![](fig/ballwater4a.svg){alt='A new concept map. "Ball" remains at left, and "Water", at right. "Size" and "Weight" are stacked vertically between them. Arrows from "Ball" share the label "Can have more or less." One arrow from "size to "water" is labeled "Affects pushing of"'}
+![](fig/ballwater4a.svg){alt="A new concept map. \"Ball\" remains at left, and \"Water\", at right. \"Size\" and \"Weight\" are stacked vertically between them. Arrows from \"Ball\" share the label \"Can have more or less.\" One arrow from \"size to \"water\" is labeled \"Affects pushing of\""}
 
-When mental models break, learning can occur more slowly than you might expect. The longer a prior model was in use, and the more extensively it has to be *unlearned*, the more it can actively interfere with the incorporation of new knowledge. Our child may quickly adapt to this new information if they had never thought much about mass before and were simply trying out an existing mental model on a new situation. However, if they had extensive experience with balls that were both larger and heavier (for example), it may take longer to unlearn what they thought they understood about mass.
+When mental models break, learning can occur more slowly than you might
+expect. The longer a prior model was in use, and the more extensively it
+has to be *unlearned*, the more it can actively interfere with the
+incorporation of new knowledge. Our child may quickly adapt to this new
+information if they had never thought much about mass before and were
+simply trying out an existing mental model on a new situation. However,
+if they had extensive experience with balls that were both larger and
+heavier (for example), it may take longer to unlearn what they thought
+they understood about mass.
 
-Most mental models worth mapping are not so simple. Yet, forcing complex ideas in to this simplified format can be useful when preparing to teach, because
-it forces you to be explicit about exactly what concepts are at the heart of your topic, and to name relationships between them.
+Most mental models worth mapping are not so simple. Yet, forcing complex
+ideas in to this simplified format can be useful when preparing to
+teach, because it forces you to be explicit about exactly what concepts
+are at the heart of your topic, and to name relationships between them.
 
 ### Types of Misconceptions
 
-Correcting learners' misconceptions is at least as important as presenting them with correct information.
-There are many ways of classifying different types of misconceptions. For our purposes, it is useful to consider
-3 broad categories:
+Correcting learners' misconceptions is at least as important as
+presenting them with correct information. There are many ways of
+classifying different types of misconceptions. For our purposes, it is
+useful to consider 3 broad categories:
 
-- Simple *factual errors*. These exist in isolation from any deeper understanding.
-  These are the easiest to correct. Example: believing that Vancouver is the capital of British Columbia.
-- *Broken models*. These occur when inaccuracies explain relationships and generate predictions (often successfully!) in an existing mental model.
-  These take time to address, demanding that learners reason carefully through examples to see contradictions.
-  Examples: believing that motion and acceleration must always be in the same direction, or that seasons are related to the shape of the earth's orbit.
-- *Fundamental beliefs*, which are deeply connected to a learner's social identity
-  and are the hardest to change. Examples: "the world is only a few thousand years old"
-  or "human beings cannot affect the planet's climate". "I am not a computational person" may, arguably, also fall into this category of misconception.
+-   Simple *factual errors*. These exist in isolation from any deeper
+    understanding. These are the easiest to correct. Example: believing
+    that Vancouver is the capital of British Columbia.
+-   *Broken models*. These occur when inaccuracies explain relationships
+    and generate predictions (often successfully!) in an existing mental
+    model. These take time to address, demanding that learners reason
+    carefully through examples to see contradictions. Examples:
+    believing that motion and acceleration must always be in the same
+    direction, or that seasons are related to the shape of the earth's
+    orbit.
+-   *Fundamental beliefs*, which are deeply connected to a learner's
+    social identity and are the hardest to change. Examples: "the world
+    is only a few thousand years old" or "human beings cannot affect the
+    planet's climate". "I am not a computational person" may, arguably,
+    also fall into this category of misconception.
 
-The middle category of misconceptions is the most useful type to watch out for in Carpentries workshops.
-While teaching, we want to expose learners' broken models so that we can help them begin to deconstruct them and build better ones in their place.
+The middle category of misconceptions is the most useful type to watch
+out for in Carpentries workshops. While teaching, we want to expose
+learners' broken models so that we can help them begin to deconstruct
+them and build better ones in their place.
 
-:::::::::::::::::::::::::::::::::::::::  challenge
-
+::: challenge
 ## Anticipating Misconceptions
 
 Describe a misconception you have encountered as a teacher or as a learner.
 
 This exercise should take about 5 minutes.
-
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
+:::
 
 ## Using Formative Assessment to Identify Misconceptions
 
-In order to effectively root out pre-existing misconceptions
-that need to be un-learned and stop quietly developing
-misconceptions in their tracks, an Instructor needs to be actively and persistently looking for them. But how?
+In order to effectively root out pre-existing misconceptions that need
+to be un-learned and stop quietly developing misconceptions in their
+tracks, an Instructor needs to be actively and persistently looking for
+them. But how?
 
-Like so many challenges we will discuss in this training, the answer is **feedback**. In this case, we want feedback
-that allows us to **assess** the developing mental model of a trainee in highly specific ways, to verify that learning
-is proceeding according to plan and not careening off in some unpredicted direction. We want to get this feedback **while we teach**
-so that we can respond to that information and adapt our instruction to get learners back on track.
+Like so many challenges we will discuss in this training, the answer is
+**feedback**. In this case, we want feedback that allows us to
+**assess** the developing mental model of a trainee in highly specific
+ways, to verify that learning is proceeding according to plan and not
+careening off in some unpredicted direction. We want to get this
+feedback **while we teach** so that we can respond to that information
+and adapt our instruction to get learners back on track.
 
-This kind of assessment has a name: it is called **formative assessment** because it is applied during learning to form
-the practice of teaching and the experience of the learner. This is different from exams, for example,
-which sum up what a participant has learned but are not used to guide further progress
-and are hence called **summative**.
+This kind of assessment has a name: it is called **formative
+assessment** because it is applied during learning to form the practice
+of teaching and the experience of the learner. This is different from
+exams, for example, which sum up what a participant has learned but are
+not used to guide further progress and are hence called **summative**.
 
-Feedback from formative assessment illuminates misconceptions for both Instructors and learners. It also provides
-reassurance on both sides when learning *is* proceeding on track! It is far more reliable than reading faces
-or using feelings of comfort as a metric, which tends to be what Instructors and learners default to
-otherwise.
+Feedback from formative assessment illuminates misconceptions for both
+Instructors and learners. It also provides reassurance on both sides
+when learning *is* proceeding on track! It is far more reliable than
+reading faces or using feelings of comfort as a metric, which tends to
+be what Instructors and learners default to otherwise.
 
-:::::::::::::::::::::::::::::::::::::::  challenge
-
+::: challenge
 ## Formative Assessments
 
-Any instructional tool that generates feedback that is used in a formative way can be described as "formative assessment."
-Based on your previous educational experience (or even this training so far!)
-what types of formative assessments do you know about?
+Any instructional tool that generates feedback that is used in a
+formative way can be described as "formative assessment." Based on your
+previous educational experience (or even this training so far!) what
+types of formative assessments do you know about?
 
-Write your answers in the Etherpad; or go around and have each person in the group name one.
+Write your answers in the Etherpad; or go around and have each person in
+the group name one.
 
 This exercise should take about 5 minutes.
+:::
 
+Formative assessments can serve many purposes other than hunting down
+misconceptions, such as verifying engagement or supporting memory
+consolidation. We will discuss some of these functions in later
+episodes. In this section, we are interested quite narrowly in
+evaluating mental models.
 
-::::::::::::::::::::::::::::::::::::::::::::::::::
+One example of formative assessment that can be used to tease out
+misconceptions is the multiple choice question (MCQ). When designed
+carefully, these can target anticipated misconceptions with surgical
+precision. For example, suppose we are teaching children multi-digit
+addition. A well-designed MCQ would be:
 
-Formative assessments can serve many purposes other than hunting down misconceptions, such as verifying
-engagement or supporting memory consolidation. We will discuss some of these functions
-in later episodes. In this section, we are interested quite narrowly in evaluating mental models.
-
-One example of formative assessment that can be used to tease out misconceptions is
-the multiple choice question (MCQ).
-When designed carefully,
-these can target anticipated misconceptions with surgical precision.
-For example,
-suppose we are teaching children multi-digit addition.
-A well-designed MCQ would be:
-
-```source
+``` source
 Q: what is 27 + 15 ?
 a) 42
 b) 32
@@ -323,184 +395,173 @@ c) 312
 d) 33
 ```
 
-The correct answer is 42,
-but each of the other answers provides valuable insight.
+The correct answer is 42, but each of the other answers provides
+valuable insight.
 
-:::::::::::::::::::::::::::::::::::::::  challenge
-
+:::: challenge
 ## Identify the Misconceptions
 
-Choose one wrong answer and write in the Etherpad what misconception is associated with that wrong answer.
-This discussion should take about 5 minutes.
+Choose one wrong answer and write in the Etherpad what misconception is
+associated with that wrong answer. This discussion should take about 5
+minutes.
 
-:::::::::::::::  solution
-
+::: solution
 ## Solution
 
-- If the child answers 32, they are throwing away the carry completely.
-- If they answer 312, they know that they cannot just discard the carried '1',
-  but do not understand that it is actually a ten
-  and needs to be added into the next column.
-  In other words,
-  they are treating each column of numbers as unconnected to its neighbors.
-- If they answer 33 then they know they have to carry the 1,
-  but are carrying it back into the same column it came from.
-  
-  
+-   If the child answers 32, they are throwing away the carry
+    completely.
+-   If they answer 312, they know that they cannot just discard the
+    carried '1', but do not understand that it is actually a ten and
+    needs to be added into the next column. In other words, they are
+    treating each column of numbers as unconnected to its neighbors.
+-   If they answer 33 then they know they have to carry the 1, but are
+    carrying it back into the same column it came from.
+:::
+::::
 
-:::::::::::::::::::::::::
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-Each of these incorrect answers has **diagnostic power**. 
-Each answer looks like it could be right:
-silly answers like "a fish!" offer therapeutic comedy but do not provide insight; nor do answers that
-are wrong in random ways.
-"Diagnostic power" means that each of the wrong choices helps the instructor figure out
-precisely what misconceptions learners have adopted when they select that choice.
+Each of these incorrect answers has **diagnostic power**. Each answer
+looks like it could be right: silly answers like "a fish!" offer
+therapeutic comedy but do not provide insight; nor do answers that are
+wrong in random ways. "Diagnostic power" means that each of the wrong
+choices helps the instructor figure out precisely what misconceptions
+learners have adopted when they select that choice.
 
 Formative assessments are most powerful when:
 
-1. **all learners** are effectively assessed (not only the most vocal ones!) AND
-2. an **instructor responds promptly to the results of the assessment**
+1.  **all learners** are effectively assessed (not only the most vocal
+    ones!) AND
+2.  an **instructor responds promptly to the results of the assessment**
 
-An instructor may learn they need to change their pace or review a particular concept.
-Using formative assessment effectively to discover and address misconceptions
-is a teaching skill that you can develop with reflective practice.
+An instructor may learn they need to change their pace or review a
+particular concept. Using formative assessment effectively to discover
+and address misconceptions is a teaching skill that you can develop with
+reflective practice.
 
-:::::::::::::::::::::::::::::::::::::::  challenge
-
+:::: challenge
 ## Handling Outcomes
 
-Formative assessments allow us as instructors to adapt our instruction to our audience.
-What options do we have if a majority of the class chooses:
+Formative assessments allow us as instructors to adapt our instruction
+to our audience. What options do we have if a majority of the class
+chooses:
 
-1. mostly one of the wrong answers?
-2. mostly the right answer?
-3. an even spread among options?
+1.  mostly one of the wrong answers?
+2.  mostly the right answer?
+3.  an even spread among options?
 
-Choose one of the above scenarios and compose a suggested response to it in the Etherpad.
+Choose one of the above scenarios and compose a suggested response to it
+in the Etherpad.
 
 This discussion should take about 5 minutes.
 
-:::::::::::::::  solution
-
+::: solution
 ## Solution
 
-1. If the majority of the class votes for a single wrong answer, you have a widespread misconception
-  and can stop to examine and correct that misconception.
-2. If most of the class votes
-  for the right answer, it is ok to explain the answer and move on. Helpers can make
-  themselves available to assist anyone who still feels uncertain.
-3. If answers are pretty evenly
-  split between options, learners may be guessing randomly, reflecting an
-  absent mental model rather than a broken one. In this case it is a good
-  idea to go back to a point where everyone was on the same page.
-  
-  
+1.  If the majority of the class votes for a single wrong answer, you
+    have a widespread misconception and can stop to examine and correct
+    that misconception.
+2.  If most of the class votes for the right answer, it is ok to explain
+    the answer and move on. Helpers can make themselves available to
+    assist anyone who still feels uncertain.
+3.  If answers are pretty evenly split between options, learners may be
+    guessing randomly, reflecting an absent mental model rather than a
+    broken one. In this case it is a good idea to go back to a point
+    where everyone was on the same page.
+:::
+::::
 
-:::::::::::::::::::::::::
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-Designing a few MCQs with diagnostic power is useful
-when preparing to teach even if they are never used, for the same reason that concept
-mapping can be useful: it forces the instructor to think about the learners' mental models
-and try to anticipate how they might be broken. In short, it helps Instructors
-to put themselves into the learners' heads
-and see the topic from their point of view. We will talk more about the process of preparing to teach
-in a later episode.
+Designing a few MCQs with diagnostic power is useful when preparing to
+teach even if they are never used, for the same reason that concept
+mapping can be useful: it forces the instructor to think about the
+learners' mental models and try to anticipate how they might be broken.
+In short, it helps Instructors to put themselves into the learners'
+heads and see the topic from their point of view. We will talk more
+about the process of preparing to teach in a later episode.
 
 ## The Importance of Going Slowly
 
-It takes work to actively assess mental models throughout a workshop; this also takes time. This
-can make Instructors feel conflicted about using formative assessment routinely. However, the need to
-conduct routine assessment is not the only reason why a workshop **should proceed more slowly than you think**.
+It takes work to actively assess mental models throughout a workshop;
+this also takes time. This can make Instructors feel conflicted about
+using formative assessment routinely. However, the need to conduct
+routine assessment is not the only reason why a workshop **should
+proceed more slowly than you think**.
 
-One key insight from research on cognitive development is that
-novices, competent practitioners, and experts each need to be taught differently.
-In particular,
-presenting novices with a pile of facts early on is counter-productive,
-because they do not yet have a model or framework to fit those facts into.
-In fact,
-**presenting too many facts too soon can actually reinforce
-an incorrect mental model**. (This is a key problem with the "empty vessel" analogy described earlier.)
+One key insight from research on cognitive development is that novices,
+competent practitioners, and experts each need to be taught differently.
+In particular, presenting novices with a pile of facts early on is
+counter-productive, because they do not yet have a model or framework to
+fit those facts into. In fact, **presenting too many facts too soon can
+actually reinforce an incorrect mental model**. (This is a key problem
+with the "empty vessel" analogy described earlier.)
 
-Most learners coming to Carpentries lessons are novices,
-and do not have a strong mental model of the concepts we are teaching.
-Thus, our primary goal is **not**
-to teach the syntax of a particular programming language, but **to help them construct a working mental model**
-so that they have something to attach facts to. In other words, our goal is to teach people **how to think** about programming and data
-management in a way that will allow them to learn more easily on their own or understand what they might find online.
+Most learners coming to Carpentries lessons are novices, and do not have
+a strong mental model of the concepts we are teaching. Thus, our primary
+goal is **not** to teach the syntax of a particular programming
+language, but **to help them construct a working mental model** so that
+they have something to attach facts to. In other words, our goal is to
+teach people **how to think** about programming and data management in a
+way that will allow them to learn more easily on their own or understand
+what they might find online.
 
-:::::::::::::::::::::::::::::::::::::  testimonial
+::: testimonial
+If someone feels it is too slow, they will be a bit bored. If they feel
+it is too fast, they will never come back to programming. — Kunal
+Marwaha, SWC Instructor
+:::
 
-If someone feels it is too slow, they will be a bit bored. If they feel it is too fast, they will never come back to programming.
-— Kunal Marwaha, SWC Instructor
+If our goal is to help novices construct an accurate and useful mental
+model of a new intellectual domain, this will impact our teaching. For
+example, we principally want to help learners form the right categories
+and make connections among concepts. We *do not* want to overload them
+with a slew of unrelated facts, as this will be confusing.
 
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-If our goal is to help novices construct an accurate and useful mental model of a new intellectual domain,
-this will impact our teaching. For example, we principally want to help learners
-form the right categories and make connections among concepts.  We *do not*
-want to overload them with a slew of unrelated facts, as this will be confusing.
-
-An important practical implication of this latter point is the pace at which we teach.  
-In the first main episode of Software Carpentry's [lesson on the Unix shell][swc-shell-novice],
-which covers "Navigating Files and Directories", there are only four "commands"
-for 40 minutes of teaching. Ten minutes per command may seem glacially slow,
-but that episodes's real purpose is to teach learners about paths; later on,
-they will learn about history, wildcards, pipes and filters,
-command-line arguments, redirection,
-and all the other big ideas on which the shell depends,
-and without which people cannot understand how to use commands.
+An important practical implication of this latter point is the pace at
+which we teach.\
+In the first main episode of Software Carpentry's [lesson on the Unix
+shell](https://swcarpentry.github.io/shell-novice/), which covers
+"Navigating Files and Directories", there are only four "commands" for
+40 minutes of teaching. Ten minutes per command may seem glacially slow,
+but that episodes's real purpose is to teach learners about paths; later
+on, they will learn about history, wildcards, pipes and filters,
+command-line arguments, redirection, and all the other big ideas on
+which the shell depends, and without which people cannot understand how
+to use commands.
 
 That mental model of the shell also includes things like:
 
-- Anything you repeat manually, you will eventually get wrong
-  (so let the computer repeat things for you by using tab completion
-  and the `history` command).
-- Lots of little tools, combined as needed, are more productive than
-  a handful of programs.
-  (This motivates the pipe-and-filter model.)
+-   Anything you repeat manually, you will eventually get wrong (so let
+    the computer repeat things for you by using tab completion and the
+    `history` command).
+-   Lots of little tools, combined as needed, are more productive than a
+    handful of programs. (This motivates the pipe-and-filter model.)
 
-These two examples illustrate something else as well.
-Learning consists of more than "just" adding information to mental models;
-creating linkages between concepts and facts is at least as important.
-Telling people that they should not repeat things,
-and that they should try to think (by analogy) in terms of little pieces loosely joined,
-both set the stage for discussing functions.
-Explicitly referring back to pipes and filters in the shell when introducing functions
-helps solidify both ideas.
+These two examples illustrate something else as well. Learning consists
+of more than "just" adding information to mental models; creating
+linkages between concepts and facts is at least as important. Telling
+people that they should not repeat things, and that they should try to
+think (by analogy) in terms of little pieces loosely joined, both set
+the stage for discussing functions. Explicitly referring back to pipes
+and filters in the shell when introducing functions helps solidify both
+ideas.
 
-:::::::::::::::::::::::::::::::::::::::::  callout
-
+::: callout
 ## Meeting Learners Where They Are
 
-One of the strengths of Carpentries workshops is that we meet learners *where they are*. Carpentries Instructors
-strive to help learners
-progress from whatever starting point they happen to be at, without making anyone
-feel inferior about their current practices or skillsets. We do this in part by teaching relevant and useful skills,
-building an inclusive learning environment, and continually getting (and paying attention to!) feedback
-from learners. We will be talking in more depth about each of these strategies as we go forward in our workshop.
+One of the strengths of Carpentries workshops is that we meet learners
+*where they are*. Carpentries Instructors strive to help learners
+progress from whatever starting point they happen to be at, without
+making anyone feel inferior about their current practices or skillsets.
+We do this in part by teaching relevant and useful skills, building an
+inclusive learning environment, and continually getting (and paying
+attention to!) feedback from learners. We will be talking in more depth
+about each of these strategies as we go forward in our workshop.
+:::
 
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-[wikipedia-dreyfus-skill]: https://en.wikipedia.org/wiki/Dreyfus_model_of_skill_acquisition
-[nurses-dreyfus]: https://journals.sagepub.com/doi/10.1177/0270467604265061
-[Benner-dreyfus]: https://www.worldcat.org/search?q=au%3ABenner%2C+Patricia+E.
-[swc-shell-novice]: https://swcarpentry.github.io/shell-novice/
-
-
-:::::::::::::::::::::::::::::::::::::::: keypoints
-
-- Our goal when teaching novices is to help them construct useful mental models.
-- Exploring our own mental models can help us prepare to convey them.
-- Constructing a useful mental model requires practice and corrective feedback.
-- Formative assessments provide practice for learners and feedback to learners and instructors.
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-
+::: keypoints
+-   Our goal when teaching novices is to help them construct useful
+    mental models.
+-   Exploring our own mental models can help us prepare to convey them.
+-   Constructing a useful mental model requires practice and corrective
+    feedback.
+-   Formative assessments provide practice for learners and feedback to
+    learners and instructors.
+:::

--- a/episodes/02-practice-learning.md
+++ b/episodes/02-practice-learning.md
@@ -248,17 +248,14 @@ a somewhat more complex mental model, perhaps illustrated as:
 ::: challenge
 ## Mapping a Mental Model
 
-1)  On a piece of paper, draw a simplified concept map of the same
-    concept you discussed in the last activity, but this time without
-    the analogy. What are 3-4 core concepts involved? How are those
-    concepts related? (Note: if you would like to try out an online tool
-    for this exercise, visit [Excalidraw](https://excalidraw.com) at [https://excalidraw.com](https://excalidraw.com).)
+1)  On a piece of paper, draw a simplified concept map of the same concept you discussed in the last activity, but this time without the analogy. What are 3-4 core concepts involved? How are those concepts related?
 
-2)  In the Etherpad, write some notes on this process. Was it difficult?
-    Do you think it would be a useful exercise prior to teaching about
-    your topic? What challenges might a novice face in creating a
-    concept map of this kind?
-    This exercise should take about 5 minutes.
+If you would like to try out an online tool for this exercise, visit [Excalidraw](https://excalidraw.com) at [https://excalidraw.com](https://excalidraw.com).
+
+2)  In the Etherpad, write some notes on this process. Was it difficult? Do you think it would be a useful exercise prior to teaching about your topic? What challenges might a novice face in creating a concept map of this kind?
+
+This exercise should take about 5 minutes.
+
 :::
 
 ## Misconceptions

--- a/episodes/04-expertise.md
+++ b/episodes/04-expertise.md
@@ -226,7 +226,7 @@ This exercise should take about 5 minutes.
 
 ## Solution
 
-It is hard to break the habit of trying to convince learners that a task is "easy"! A few alternatives
+It is hard to break the habit of trying to convince learners that a task is *easy*! A few alternatives
 might include statements like:
 
 - "This task will become really easy once you have learned how to do it."

--- a/episodes/04-expertise.md
+++ b/episodes/04-expertise.md
@@ -226,7 +226,7 @@ This exercise should take about 5 minutes.
 
 ## Solution
 
-It is hard to break the habit of trying to convince learners that a task is *easy*! A few alternatives
+It is hard to break the habit of trying to convince learners that a task is "easy"! A few alternatives
 might include statements like:
 
 - "This task will become really easy once you have learned how to do it."

--- a/episodes/05-memory.md
+++ b/episodes/05-memory.md
@@ -56,7 +56,7 @@ frequent formative assessment is important.
 
 ## Test Your Working Memory
 
-Try a short [test of working memory][memory-test] [https://miku.github.io/activememory/][memory-test].
+Try a short [test of working memory][memory-test] at [https://miku.github.io/activememory/][memory-test].
 
 What was your score? If you are comfortable, share your answer
 in the Etherpad.
@@ -196,7 +196,7 @@ to alternate between attending to, which can reduce efficiency and performance o
 
 ### The Theory of Cognitive Load
 
-There are different [theories of cognitive load][wikipedia-cognitive-load]. In one of these, [Sweller posits that people have to attend to three types of things when they are learning](https://doi.org/10.1207/s15516709cog1202_4):
+There are different [theories of cognitive load][wikipedia-cognitive-load]. In one of these, [Sweller](https://doi.org/10.1207/s15516709cog1202_4)  posits that people have to attend to three types of things when they are learning:
 
 - Things they have to think about in order to **perform a task** ("intrinsic").
 - Mental effort required to **connect the task** to new and old information ("germane").

--- a/episodes/06-feedback.md
+++ b/episodes/06-feedback.md
@@ -48,7 +48,7 @@ all the questions, you can preview them in a text-format below:
 When The Carpentries Workshop Administration Team sets up the surveys for your workshop, they will also send you a link to
 a dashboard with the results! Take care not to share this link with your learners.
 
-- This link will take you to a [dashboard](https://workshop-reports.carpentries.org/?aggregate-workshops) displaying data from past workshop surveys, so you can have an idea of what to expect for your workshop.
+- The carpentries maintains a [dashboard](https://workshop-reports.carpentries.org/?aggregate-workshops) displaying data from past workshop surveys, so you can have an idea of what to expect for your workshop.
 
 :::::::::::::::::::::::::::::::::::::::  checklist
 

--- a/episodes/06-feedback.md
+++ b/episodes/06-feedback.md
@@ -48,9 +48,7 @@ all the questions, you can preview them in a text-format below:
 When The Carpentries Workshop Administration Team sets up the surveys for your workshop, they will also send you a link to
 a dashboard with the results! Take care not to share this link with your learners.
 
-- This link will take you to a [dashboard displaying the last year of data for our workshop
-  surveys](https://workshop-reports.carpentries.org/?aggregate-workshops) so you can have an idea of
-  what to expect for your workshop.
+- This link will take you to a [dashboard](https://workshop-reports.carpentries.org/?aggregate-workshops) displaying data from past workshop surveys, so you can have an idea of what to expect for your workshop.
 
 :::::::::::::::::::::::::::::::::::::::  checklist
 

--- a/episodes/08-motivation.md
+++ b/episodes/08-motivation.md
@@ -61,7 +61,7 @@ things in the opposite corner
 that are time-consuming to learn and have little near-term application
 should be avoided in our workshops.
 
-![](fig/what-to-teach.png){alt='A stylized graph with y-axis labeled "usefulness once mastered" and and x-axis labeled "mean time to master". The upper left quadrant says "teach this first" and the lower right quadrant says "do not bother".'}
+![](fig/what-to-teach.png){alt='A stylized graph with y-axis labeled "usefulness once mastered" and and x-axis labeled "mean time to master". The upper left quadrant says "teach this first" and the lower right quadrant says "don't bother".'}
 
 Another way to think about the graph shown above is **authentic tasks** -- real tasks performed
 by someone doing their work. If you can identify authentic tasks from your
@@ -133,10 +133,10 @@ confusion or doubt. Creating a motivating classroom means inviting communication
 
 A few ways to invite participation are:
 
-- **Establishing norms for interaction**. This can be done by creating procedures for communication, e.g. turn taking in discussions, passing around a 'talking
-  stick', or encouraging quieter people to contribute. Having, discussing, and enforcing a [Code of Conduct](https://docs.carpentries.org/policies/coc/)
+- **Establishing norms for interaction**. This can be done by creating procedures for communication, e.g. turn taking in discussions, passing around a *talking
+  stick*, or encouraging quieter people to contribute. Having, discussing, and enforcing a [Code of Conduct](https://docs.carpentries.org/policies/coc/)
   also provides a framework for positive communication to occur.
-- **Encouraging learners to learn from each other**. Working in pairs, or "[pair programming](https://en.wikipedia.org/wiki/Pair_programming)," encourages
+- **Encouraging learners to learn from each other**. Working in pairs, or *[pair programming](https://en.wikipedia.org/wiki/Pair_programming)*, encourages
   learners to talk through their learning process, reinforcing memory and making it more likely that confusion will be expressed and
   resolved. This can also address challenges of varying background experience: asking more advanced learners to help beginners can
   maximize learning for both. In these cases, make sure the beginner is doing the typing!
@@ -146,7 +146,7 @@ A few ways to invite participation are:
 ### Encourage a Growth Mindset
 
 People vary in their beliefs about the nature of intelligence and skill development. In academic environments, people
-are often praised as "talented" or having "high ability," and may develop an identity around being a certain "type of
+are often praised as *talented* or having *high ability*, and may develop an identity around being a certain "type of
 person" who has inherent strengths or weaknesses.
 
 The belief that ability or intelligence is born rather than made -- dubbed a **fixed mindset** by Carol Dweck -- may impact the learning process. Broadly, this is a
@@ -261,7 +261,7 @@ serious hazards in the classroom! Here are a few **things you should not do in y
   or "You've never heard of Y?" signals to the learner that they do not have
   some required pre-knowledge of the material you are teaching, that they don't belong at the workshop,
   and it may prevent them from asking questions in
-  the future. (For more on this see the Recurse Center's [Social Rules][recurse-social-rules]).
+  the future. For more on this see the Recurse Center's [Social Rules][recurse-social-rules].
 
 It can be difficult to avoid these demotivators entirely. Some people are so used to
 complaining about certain tools

--- a/episodes/08-motivation.md
+++ b/episodes/08-motivation.md
@@ -61,7 +61,7 @@ things in the opposite corner
 that are time-consuming to learn and have little near-term application
 should be avoided in our workshops.
 
-![](fig/what-to-teach.png){alt='A stylized graph with y-axis labeled "usefulness once mastered" and and x-axis labeled "mean time to master". The upper left quadrant says "teach this first" and the lower right quadrant says "don't bother".'}
+![](fig/what-to-teach.png){alt='A stylized graph with y-axis labeled "usefulness once mastered" and and x-axis labeled "mean time to master". The upper left quadrant says "teach this first" and the lower right quadrant says "do not bother".'}
 
 Another way to think about the graph shown above is **authentic tasks** -- real tasks performed
 by someone doing their work. If you can identify authentic tasks from your
@@ -146,7 +146,7 @@ A few ways to invite participation are:
 ### Encourage a Growth Mindset
 
 People vary in their beliefs about the nature of intelligence and skill development. In academic environments, people
-are often praised as *talented* or having *high ability*, and may develop an identity around being a certain "type of
+are often praised as "talented" or having "high ability", and may develop an identity around being a certain "type of
 person" who has inherent strengths or weaknesses.
 
 The belief that ability or intelligence is born rather than made -- dubbed a **fixed mindset** by Carol Dweck -- may impact the learning process. Broadly, this is a

--- a/episodes/09-eia.md
+++ b/episodes/09-eia.md
@@ -34,17 +34,10 @@ This section addresses topics related to equity, inclusion, and accessibility. T
 and may be familiar to you, but not everyone understands or interprets them in the same way. So, we will start
 with a few working definitions, adapted from the [University of Pittsburgh DEI Glossary][glossary]:
 
-**Equity:** The proportional distribution of desirable outcomes across groups. Sometimes confused with equality,
-equity refers to outcomes while equality connotes equal treatment.
-
-**Inclusion:**  Actively engaging traditionally excluded individuals and/or groups in processes, activities
-and decisions in a way that shares power. Inclusion promotes broad engagement, shared participation,
-and advances authentic sense of belonging through safe, positive, and nurturing environments.
-
-**Accessibility:** Refers to the intentional design or redesign of technology, policies, products, and services (to name a few)
-that increase one's ability to use, access, and obtain the respective item. Each person is afforded the opportunity to acquire
-the same information, engage in the same interactions, and enjoy the same services in an equally effective and equally
-integrated manner, with substantially equivalent ease of use.
+- **Equity:** The proportional distribution of desirable outcomes across groups. Sometimes confused with equality, equity refers to outcomes while equality connotes equal treatment.
+- **Inclusion:**  Actively engaging traditionally excluded individuals and/or groups in processes, activities and decisions in a way that shares power. Inclusion promotes broad engagement, shared participation, and advances authentic sense of belonging through safe, positive, and nurturing environments.
+- **Accessibility:** Refers to the intentional design or redesign of technology, policies, products, and services (to name a few) that increase one's ability to use, access, and obtain the respective item. Each person is afforded the opportunity to acquire
+the same information, engage in the same interactions, and enjoy the same services in an equally effective and equally integrated manner, with substantially equivalent ease of use.
 
 ### The Carpentries Core Values
 
@@ -55,7 +48,7 @@ things that we do, things that we are, and things that we champion. Many of thes
 
 ## Discuss The Carpentries Core Values
 
-1. Take a moment to read through [The Carpentries Core Values][core-values] [https://carpentries.org/about-us/#our-values][core-values]
+1. Take a moment to read through [The Carpentries Core Values][core-values] at [https://carpentries.org/about-us/#our-values][core-values].
 2. Choose one core value that resonates with you. What is a decision you might make in a workshop
   that could look different if you were actively considering the core value you chose?
 
@@ -121,13 +114,12 @@ A good example of universal design is curb cuts
 and sidewalk ramps. While they were originally created to make it easier for
 wheelchair users to move around, they proved to be equally helpful to people with strollers and grocery carts.
 
-![](fig/sketchplanations-the-curb-cut-effect.png){alt='People using different wheeled devices utilising the curb cut. The picture is titled The Curb-Cut Effect and states "when we design for disabilities, we make things better for everyone."' width="600px" }
-Image: [Sketchplanations][sketchplanations-curb-cuts]
+![Image: [Sketchplanations][sketchplanations-curb-cuts]](fig/sketchplanations-the-curb-cut-effect.png){alt='People using different wheeled devices utilising the curb cut. The picture is titled The Curb-Cut Effect and states "when we design for disabilities, we make things better for everyone."' width="600px" }
 
 ### Universal Design in Learning (UDL)
 
 In the 1990s, the Center for Applied Special Technology (CAST) brought Universal Design
-into Education with the [Universal Design in Learning (UDL) Framework][CAST].
+into Education with the [Universal Design for Learning (UDL) Framework][CAST].
 UDL places responsibility for accessibility on the course designer rather than on the learner.
 It states that the most inclusive approach to education is to design instruction with diverse learners in mind from the beginning.
 

--- a/episodes/11-practice-teaching.md
+++ b/episodes/11-practice-teaching.md
@@ -121,7 +121,7 @@ in a way that facilitates growth.
   hear feedback that you have asked for.
 
 - **Be specific.** See a great example of this from
-  this [Lunar Baboon comic][lunar-babboon].
+  this [Lunar Baboon comic][lunar-baboon].
 
 As an instructor one way to get specific feedback is to provide questions that
 focus the responses.  Writing your own feedback questions allows you to frame
@@ -174,13 +174,14 @@ it is OK to remind yourself:
 We will start by observing some examples of teaching and providing some feedback.
 
 Watch this [example teaching video][bad-teaching-video] as a group 
-and then give feedback on it: [https://www.youtube.com/watch?v=-ApVt04rB4U][bad-teaching-video]
+and then give feedback on it: [https://www.youtube.com/watch?v=jxgMVwQamO0][bad-teaching-video]. 
+
+English and Spanish captions are available by clicking the settings icon in the video.
+
 Put your feedback in the Etherpad.
 Organize your feedback along two axes:
-positive vs. opportunities for growth (sometimes called "negative")
-and content (what was said) vs. presentation (how it was said).
-
-Note: there is [a version of this video with subtitles in both Spanish and English](https://www.youtube.com/watch?v=jxgMVwQamO0) [https://www.youtube.com/watch?v=jxgMVwQamO0](https://www.youtube.com/watch?v=jxgMVwQamO0)
+- positive vs. opportunities for growth (sometimes called "negative") and
+- content (what was said) vs. presentation (how it was said).
 
 This exercise should take about 10 minutes.
 
@@ -273,8 +274,8 @@ practice teaching and to get and give feedback in parts 3 and 4.
 [fincher-warren]: files/papers/fincher-warrens-questions-2007.pdf
 [fincher-stories]: files/papers/fincher-stories-change-2012.pdf
 [barker-practice]: files/papers/barker-practice-adoption-2015.pdf
-[lunar-babboon]: https://web.archive.org/web/20210513225525/http://www.lunarbaboon.com/comics/feedback.html
-[bad-teaching-video]: https://www.youtube.com/watch?v=-ApVt04rB4U
+[lunar-baboon]: https://web.archive.org/web/20210513225525/http://www.lunarbaboon.com/comics/feedback.html
+[bad-teaching-video]: https://www.youtube.com/watch?v=jxgMVwQamO0
 
 
 :::::::::::::::::::::::::::::::::::::::: keypoints

--- a/episodes/13-second-welcome.md
+++ b/episodes/13-second-welcome.md
@@ -52,8 +52,9 @@ we will conclude our training with a discussion about workshop logistics that wi
 
 At the end of part 2, we asked you to read some resources about the logistics of teaching and running Carpentries workshops. Please
 add your questions about logistics and preparation to the Etherpad. We will answer these questions in the Etherpad during your work time
-and will return to this list later in the training. We may draw on the [Workshop FAQ](https://carpentries.org/workshops/workshops-faq/), which you
-can also refer to later if you have additional questions.
+and will return to this list later in the training. 
+
+If you have additional questions after the training, you can refer to the [Workshop FAQ](https://carpentries.org/workshops/workshops-faq/) at [https://carpentries.org/workshops/workshops-faq/](https://carpentries.org/workshops/workshops-faq/).
 
 This activity should take about 5 minutes.
 

--- a/episodes/14-checkout.md
+++ b/episodes/14-checkout.md
@@ -37,7 +37,8 @@ Extensions may be granted for any reason up to 1 year from your training date.
 
 ## Be The Expert: Checkout Q \& A
 
-In small groups, read and discuss one of [the three checkout procedures](checkout.md) [https://carpentries.github.io/instructor-training/checkout/index.html](checkout.md).
+In small groups, read and discuss one of [the three checkout steps](checkout.md) at [https://carpentries.github.io/instructor-training/checkout/index.html](checkout.md).
+
 Make notes in the Etherpad:
 
 - What points do you think it is most important or helpful for people to remember?
@@ -68,7 +69,7 @@ This exercise should take 5 minutes.
 ### What does a badge mean?
 
 - **You can teach any Carpentries workshops!** Carpentries Instructor badges are valid to teach any Software Carpentry, Data Carpentry, or Library Carpentry lesson. You can teach branded workshops locally, or network with experienced co-Instructors as a volunteer with our global community. While local co-Instructors need not be badged or experienced, every Carpentries branded workshop must have at least one badged Instructor to lead the way. (More on branding in the next episode!)
-- **You get to vote!** Badged Instructors are eligible to vote in Carpentries Executive Council elections for their first year, and for all subsequent years in which they continue to participate through teaching or other involvement. See [this section from the Carpentries Bylaws][voting-rights] for rules governing continuing voting eligibility.
+- **You get to vote!** Badged Instructors are eligible to vote in Carpentries Executive Council elections for their first year, and for all subsequent years in which they continue to participate through teaching or other involvement. See the [Carpentries Bylaws][voting-rights] for rules governing continuing voting eligibility.
 - **You can share!** Looking for language to add to showcase your skills and experience on a CV or resume? [Here is some text][text-for-instructors] to get you started!
 
 :::::::::::::::::::::::::::::::::::::::: keypoints

--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -51,6 +51,7 @@ ways you might wish to participate (including by teaching workshops!).
 ## A Brief History
 
 [Software Carpentry](https://software-carpentry.org/) was founded in 1998 with the mission of teaching lab skills for research computing.
+
 [Data Carpentry](https://datacarpentry.org/) was founded in 2014 with the mission of building communities teaching universal data literacy.
 
 Also in 2014, [Library Carpentry](https://librarycarpentry.org/) was founded with the mission of teaching data skills to people working in library- and information-related roles.
@@ -71,10 +72,11 @@ Carpentries communities may include many participants who are not necessarily co
 
 ![](fig/SWCDChistory.png){alt='A very brief history of The Carpentries. A timeline - 1998 Software Carpentry is founded by Greg Wilson and Bret Gorda to teach researchers better software development skills. 2005 lesson materials are made open source with support from the Python Software Foundation. 2012 Software Carpentry workshop efforts scale with support from the Alfred P. Sloan Foundation and the Mozilla Science Lab. 2013 the first Software Carpentry for Librarians workshops are organised in the US and Canada. 2014 Data Carpentry is founded by Karen Cranston, Hilmar Lapp, Tracy Teal, and Ethan White with support from the National Science Foundation. James Baker receives support from the Software Sustainability Institute to develop and implement Library Carpentry. Software Carpentry Foundation is founded under the auspices of NumFOCUS. 2015 - Data Carpentry workshop efforts scaled with support from the Gordon and Betty Moore Foundation. 2018 in January, Software Carpentry and Data Carpentry merge to form The Carpentries, a fiscally sponsored project of Community Initiatives. In November, Library Carpentry joins as a Lesson Program.'}
 
-You can learn more about the history and goals of each Lesson Program by reading
-"[Software Carpentry: Lessons Learned][F1000]",
-"[Data Carpentry: Workshops to Increase Data Literacy for Researchers][IJDC]" and
-"[Library Carpentry: software skills training for library professionals][LIBERQ]"".
+You can learn more about the history and goals of each Lesson Program by reading:
+
+- [Software Carpentry: Lessons Learned][F1000]
+- [Data Carpentry: Workshops to Increase Data Literacy for Researchers][IJDC]
+- [Library Carpentry: software skills training for library professionals][LIBERQ]
 
 ## Similarities and Differences between The Carpentries Lesson Programs
 
@@ -112,7 +114,9 @@ certified instructors.
 
 ## Local Support
 
-There are several helpful [Workshop Checklists and Suggestions][docs-workshop-checklists] in the handbook. The Helper checklist recommends at least a 1:10
+The handbook includes several helpful [Workshop Checklists and Suggestions][docs-workshop-checklists]: [https://docs.carpentries.org/resources/workshops/checklists.html](https://docs.carpentries.org/resources/workshops/checklists.html) 
+
+The Helper checklist recommends at least a 1:10
 helper-to-learner ratio for in-person workshops (not counting instructors) and more if teaching online.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -192,7 +196,7 @@ Once you have selected your workshop type, consult [**The Carpentries Handbook**
 The Carpentries Handbook is the definitive source for policies and information, including tips, checklists, and points of contact for nearly all
 Carpentries-related activities. A few examples of useful content include:
 
-- template emails and checklists for Hosts, Instructors, and Helpers in [The Carpentries Handbook: Teaching and Hosting][docs-teach-host]
+- [template emails and checklists][docs-teach-host] for Hosts, Instructors, and Helpers
 - the [instructor no-show policy][docs-noshow] which is important to read before signing up for your first workshop
 
 As The Carpentries grows and changes in response to a complex global legal landscape, our policies and procedures are likely to change. Be sure to check
@@ -242,7 +246,7 @@ Library Carpentry lesson format, you can find two Workbench lesson templates ava
 Any lesson that uses The Carpentries lesson templates follows our [Code of Conduct][coc], 
 and is licensed either [CC-BY][cc-by] or [CC-0][cc-0] can be hosted in [The Carpentries Incubator][carpentries-incubator].
 
-[The Collaborative Lesson Development Training curriculum][cld] provides a guide to
+The [Collaborative Lesson Development Training][cld] curriculum provides a guide to
 the backward design approach we recommend for lesson development. This curriculum is part of our official
 teaching offerings; please contact [The Carpentries](mailto:team@carpentries.org) if you are interested in taking
 this course.
@@ -267,10 +271,16 @@ Whatever your interests or strengths, we hope you will find a place where you ca
 
 ## Community Roles
 
-Select one role from the list below that interests you. Using the the descriptions on [The Carpentries community website][community-page], write
+Select one role from the list below that interests you. Using the the descriptions on [The Carpentries community website][community-page] at [https://carpentries.org/community/](https://carpentries.org/community/).
 
-1) a short definition of the role and 2) a question that you have (or that you imagine someone else might have) about the role. Are there roles you
-  would like to see that are not listed? Note that, too!
+Write:
+
+- a short definition of the role and
+- a question that you have (or that you imagine someone else might have) about the role. 
+
+Are there roles you would like to see that are not listed? Note that, too!
+
+**Roles**
 
 1. Governance
 2. Instructor Trainers
@@ -307,7 +317,8 @@ Want to **join meetings** (to meet new people or listen in)?
 
 ## Get Connected
 
-Take a couple of minutes to sign up for [The Carpentries communication channels][connect-page] you want to stay involved with: [https://carpentries.org/connect/][connect-page]
+Take a couple of minutes to sign up for [The Carpentries communication channels][connect-page] you want to stay involved with at [https://carpentries.org/connect/][connect-page].
+
 When you are done, share a channel you find interesting or useful on the Etherpad.
 
 This exercise should take about 5 minutes.

--- a/episodes/17-live.md
+++ b/episodes/17-live.md
@@ -34,11 +34,11 @@ and work through the lesson,
 typing in the code,
 reformatting data,
 and talking as we go.
-This is called ["live coding"](https://en.wikipedia.org/wiki/Live_coding).
+This is called **[live coding](https://en.wikipedia.org/wiki/Live_coding)**.
 However, the instructor is not live coding in a vacuum.
 Importantly, learners are strongly encouraged
-to "code-along" with the instructor.
-We refer to the practice of having the instructor live code and the learners code along as "participatory live coding" or, less formally, 'code-along sessions'.
+to **code-along** with the instructor.
+We refer to the practice of having the instructor live code and the learners code along as **participatory live coding** or, less formally, **code-along sessions**.
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
@@ -101,22 +101,28 @@ Many error messages are obscure and not written with novices in mind. Continue t
 - Learning to parse error messages is an important step in developing debugging skills.
 
 - **Intentional vs accidental errors** - It can be useful to intentionally demonstrate common mistakes and error messages. Alternatively, mistakes made by the Instructor or learners can offer useful opportunities to learn about and positively frame errors.
+::: instructor
+
+For the next exercise, please turn on closed captions using the "CC"" button for the videos, both for accessibility and because sound quality is poor in places.
+
+:::
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
 ## Compare and Contrast
 
-Watch this first participatory live coding demo video: [https://youtu.be/bXxBeNkKmJE][live-coding-bad]
-and this second demo video: [https://youtu.be/SkPmwe\_WjeY][live-coding-good]
-as a group and then summarize your feedback on both in the Etherpad.
+Watch the following two participatory live coding demo videos as a group:
+
+- [https://youtu.be/bXxBeNkKmJE][live-coding-bad]
+- [https://youtu.be/SkPmwe\_WjeY][live-coding-good]
+
+After watching, summarize your feedback on both in the Etherpad.
 Use the 2x2 rubric for feedback we discussed earlier.
 
 In the videos, the bash shell `for` loop is taught,
 and it is assumed learners are familiar with how to use a variable,
 the `head` command and the content of the `basilisk.dat` and `unicorn.dat`
 files.
-
-Note: Sometimes sounds in the room can be poor. Turning on closed captioning by pressing the cc button will improve the accessibility of these videos.
 
 This exercise and discussion should take about 15 minutes.
 
@@ -145,7 +151,7 @@ making sure that the points of the Top Ten Tips below have been made.
 9. **Embrace mistakes.** No matter how well prepared you are, you will make mistakes. This is OK! Use these opportunities to do [error framing](08-motivation.md) and to help your learners learn the art of troubleshooting.
 10. **Have fun!** It is OK to use humor and improvisation to liven up the workshop. This becomes easier when you are more familiar with the material, and more relaxed. Start small, even just saying 'that was fun' after something worked well is a good start.
 
-Read more in [Ten quick tips for teaching with participatory live-coding][live-coding-tips-paper]
+Read more in [Ten quick tips for teaching with participatory live-coding][live-coding-tips-paper].
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
@@ -153,12 +159,8 @@ Read more in [Ten quick tips for teaching with participatory live-coding][live-c
 
 1. Split into groups of three.
 2. Assign roles, which will rotate: presenter, timekeeper, note-taker.
-3. Have each group member teach 3 minutes of your chosen lesson episode using live coding.
-  For this exercise, your peers will not "code-along." Before
-  you begin, briefly describe what you will be teaching and what has been learned previously. Do not record this exercise.
-4. After each person finishes, each group member should share feedback (starting with themselves) using the same 2x2 rubric introduced in part 2 The
-  timekeeper should keep feedback discussion to about 1 minute per person; this may leave some time at the end for general
-  discussion. The note-taker should record feedback in the Etherpad.
+3. Have each group member teach 3 minutes of your chosen lesson episode using live coding. For this exercise, your peers will not "code-along." Before you begin, briefly describe what you will be teaching and what has been learned previously. Do not record this exercise.
+4. After each person finishes, each group member should share feedback (starting with themselves) using the same 2x2 rubric introduced in part 2 The timekeeper should keep feedback discussion to about 1 minute per person; this may leave some time at the end for general discussion. The note-taker should record feedback in the Etherpad.
 5. Trade off roles.
 
 This exercise should take about 25 minutes.  

--- a/episodes/20-performance.md
+++ b/episodes/20-performance.md
@@ -26,16 +26,23 @@ process of observing and giving feedback, and to make changes to how we teach ba
 
 ## Round Two
 
-1. Before splitting into groups, read the rubric that is given to Instructor Trainers
-  as a suggested framework for evaluating the online teaching demonstration sessions that are part of Instructor checkout.  
-  [https://carpentries.github.io/instructor-training/demos_rubric.html](demos_rubric.md). (Note: demos are not scored, so this rubric is for
-  advisory purposes only.)
-  What questions do you have?
+1. Before splitting into groups, read the rubric that is given to Instructor Trainers as a suggested framework for evaluating the online teaching demonstration sessions that are part of Instructor checkout.
+
+Rubric: [https://carpentries.github.io/instructor-training/demos_rubric.html](demos_rubric.md)
+
+Note that demos are not scored, so this rubric is for advisory purposes only.
+
+**What questions do you have?**
+
 2. Return to your groups and repeat the previous live coding exercise, re-teaching the same content as before.
-  This time, the presenter should incorporate changes
-  based on feedback received, and everyone should try to 'level up' their feedback using the rubric for teaching demos.
+
+This time, the presenter should incorporate changes based on feedback received, and everyone should try to 'level up' their feedback using the rubric for teaching demos.
+
 3. When you are finished, add some thoughts on this process to the Etherpad:
-  What did you change? Did it work better or worse with the change? How might you do it if you were to teach it again?
+
+- **What did you change?**
+- **Did it work better or worse with the change?** 
+- **How might you do it if you were to teach it again?**
 
 This exercise should take about 10 minutes for rubric discussion, 25 minutes for teaching, and 10 minutes for de-brief.
 

--- a/episodes/21-management.md
+++ b/episodes/21-management.md
@@ -99,7 +99,7 @@ are expected in all Carpentries workshops. These include:
 
 #### Starting with the Code of Conduct
 
-Looking for language to introduce the Code of Conduct during your workshop? The [summary view in The Carpentries Handbook][CoC-summary] is a great template.
+Looking for language to introduce the Code of Conduct during your workshop? The [summary view][CoC-summary] in The Carpentries Handbook is a great template.
 
 #### Participatory Instruction \& Hands-off Help
 
@@ -266,14 +266,21 @@ We encourage you to **discuss an approach to managing Code of Conduct violations
 
 ## Know Your Resources
 
-1) Take 5 minutes to read through the Code of Conduct Incident Response Guidelines: [https://docs.carpentries.org/policies/coc/incident-response.html](https://docs.carpentries.org/policies/coc/incident-response.html)
-2) Discuss what you have read in small groups. As questions arise, you may wish to refer to our complete Code of Conduct section in The Carpentries Handbook:
-  [https://docs.carpentries.org/policies/coc/](https://docs.carpentries.org/policies/coc/) or to the Transparency Reports released by The Carpentries Code of Conduct Committee: [https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports](https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports)
+1. Take 5 minutes to read through the Code of Conduct [Incident Response Guidelines](https://docs.carpentries.org/policies/coc/incident-response.html) at [https://docs.carpentries.org/policies/coc/incident-response.html](https://docs.carpentries.org/policies/coc/incident-response.html).
 
-- What kinds of things could your instructional team agree upon in advance of your workshop?
-- What questions do you have about CoC enforcement?
+2. Discuss what you have read in small groups. 
 
-3) Write some notes in the Etherpad.
+As questions arise, you may wish to refer to the  resources below:
+
+- [Complete Code of Conduct](https://docs.carpentries.org/policies/coc/) at [https://docs.carpentries.org/policies/coc/](https://docs.carpentries.org/policies/coc/)
+- [Code of Conduct Committee Transparency Reports](https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports) at [https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports](https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports)
+
+Some questions to consider are:
+
+- **What kinds of things could your instructional team agree upon in advance of your workshop?**
+- **What questions do you have about CoC enforcement?**
+
+3. Write some notes in the Etherpad.
 
 This discussion should take about 10 minutes.
 
@@ -328,54 +335,15 @@ Record some notes, and share your thoughts with the group. This exercise should 
 
 ## Co-Instruction Suggestions
 
-- Coordinate who is teaching what, sufficiently in advance that
-  both instructors are confident in their preparation.
-
-- Coordinate with your instructional team. Hosts will need information
-  from you to advertise the workshop. Helpers will need to know what you
-  expect from them. More communication is better, but it is also
-  important to respect people's time.
-
-- If you have time to do some
-  advance preparation together, try drawing a concept map together or
-  teaching a short snippet of the lessons for each other.
-
-- Discuss in advance if you will provide feedback to each other
-  and how to do so (see notes above).
-
-- If it will not cause cognitive overload for you (the instructors),
-  work out a couple of hand signals to communicate.  "You are
-  going too fast", "speak up", "that learner needs help", and, "It is
-  time for a bathroom break" are all useful.
-
-- The person who is not teaching should not interrupt, offer
-  corrections, elaborations, or amusing personal anecdotes, or do
-  anything else to distract from what the person teaching at the time
-  is doing or saying.  The one exception is that it is sometimes
-  helpful to ask leading questions, particularly if the learners seem
-  unsure of themselves.
-
-- For Carpentries workshops, a single instructor usually teaches for a
-  half-day stretch (2-3 hours).  You can alternate more frequently, but
-  each person should teach for at least 10-15 minutes at a stretch,
-  since learners may be distracted by more frequent interleaving.
-
-- Each person should take a couple of minutes before they start
-  teaching to see what their partner is going to teach after they are
-  done.  This allows each instructor to set up their partner's material
-  without covering it themselves.
-
-- Whenever possible, the person who is not teaching should stay engaged
-  with the class.  Monitor the shared notes, keep an eye
-  on the learners to see who is struggling, jot down some feedback to
-  give your teaching partner at the next break - anything that
-  contributes to the lesson is better than anything that does not.  It is
-  easier for the other instructor to take a break to catch up on outside
-  work (like email) if there are at least
-  three instructors or sufficient helpers to make sure that the main
-  instructor is supported.
-  
-  
+- Coordinate who is teaching what, sufficiently in advance that both instructors are confident in their preparation.
+- Coordinate with your instructional team. Hosts will need information from you to advertise the workshop. Helpers will need to know what you expect from them. More communication is better, but it is also important to respect people's time.
+- If you have time to do some advance preparation together, try drawing a concept map together or teaching a short snippet of the lessons for each other.
+- Discuss in advance if you will provide feedback to each other and how to do so (see notes above).
+- If it will not cause cognitive overload for you (the instructors), work out a couple of hand signals to communicate. "You are going too fast", "speak up", "that learner needs help", and, "It is time for a bathroom break" are all useful.
+- The person who is not teaching should not interrupt, offer corrections, elaborations, or amusing personal anecdotes, or do anything else to distract from what the person teaching at the time is doing or saying.  The one exception is that it is sometimes helpful to ask leading questions, particularly if the learners seem unsure of themselves.
+- For Carpentries workshops, a single instructor usually teaches for a half-day stretch (2-3 hours).  You can alternate more frequently, but each person should teach for at least 10-15 minutes at a stretch, since learners may be distracted by more frequent interleaving.
+- Each person should take a couple of minutes before they start teaching to see what their partner is going to teach after they are done. This allows each instructor to set up their partner's material without covering it themselves.
+- Whenever possible, the person who is not teaching should stay engaged with the class.  Monitor the shared notes, keep an eye on the learners to see who is struggling, jot down some feedback to give your teaching partner at the next break - anything that contributes to the lesson is better than anything that does not. It is easier for the other instructor to take a break to catch up on outside work (like email) if there are at least three instructors or sufficient helpers to make sure that the main instructor is supported.
 
 :::::::::::::::::::::::::
 
@@ -406,24 +374,18 @@ instructions for setting them up.
 For this activity, your Trainer will put you in groups, but you may choose whether to work together or independently.
 If you work independently, you can still use your group as a resource to ask questions as they emerge.
 
-Go to the workshop template repository: [https://github.com/carpentries/workshop-template](https://github.com/carpentries/workshop-template)
+Go to the [workshop template repository](https://github.com/carpentries/workshop-template) at [https://github.com/carpentries/workshop-template](https://github.com/carpentries/workshop-template).
 
-- If you have a GitHub account (or don't mind creating one) and are comfortable doing so,
-  follow the directions to begin creating a workshop website using your local location and today's date.
+- If you have a GitHub account (or don't mind creating one) and are comfortable doing so, follow the directions to begin creating a workshop website using your local location and today's date.
+- Alternatively, have a look at the video tutorial linked on the instructions page. 
 
-- Alternatively, have a look at the video tutorial linked on the instructions page. With any time
-  remaining, have a look at the websites for upcoming Carpentries workshops on our website: [https://carpentries.org/upcoming\_workshops/](https://carpentries.org/upcoming_workshops/)
+With any time remaining, have a look at the websites for [upcoming workshops](https://carpentries.org/upcoming_workshops/) at [https://carpentries.org/upcoming\_workshops/](https://carpentries.org/upcoming_workshops/).
 
-- Add your questions and thoughts on this process to the Etherpad. If you created a workshop website,
-  add the link there as well.
+- Add your questions and thoughts on this process to the Etherpad. If you created a workshop website, add the link there as well.
 
 This exercise should take about 15 minutes.
 
-Note: Sometimes web browsers will cache the workshop webpage, so when
-you make changes in GitHub, they do not show up on the workshop webpage
-immediately.  Two ways to avoid this are to use a "private" or
-"incognito" mode in your web browser or by following these
-instructions to bypass your browser cache: [https://en.wikipedia.org/wiki/Wikipedia:Bypass\_your\_cache](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache).
+*Note: Sometimes web browsers will cache the workshop webpage, so when you make changes in GitHub, they do not show up on the workshop webpage immediately.  Two ways to avoid this are to use a "private" or "incognito" mode in your web browser or by following these instructions to bypass your browser cache: [https://en.wikipedia.org/wiki/Wikipedia:Bypass\_your\_cache](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache).
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/23-introductions.md
+++ b/episodes/23-introductions.md
@@ -250,7 +250,7 @@ This exercise will take about 5 minutes.
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Introduction materials are adapted from [Carnegie Mellon Eberly
-Center Teaching Excellence \& Educational Innovation][credits]
+Center Teaching Excellence \& Educational Innovation][credits].
 
 [icebreakers]: ../instructors/icebreakers.md
 [credits]: https://www.cmu.edu/teaching/designteach/teach/firstday.html

--- a/episodes/25-wrap-up.md
+++ b/episodes/25-wrap-up.md
@@ -52,7 +52,7 @@ This exercise should take 5 minutes.
 ## Post Workshop Surveys
 
 Assessment is very important to us! Please take the remaining time to complete
-this [\~5 minute post-workshop survey](https://carpentries.typeform.com/to/cjJ9UP#slug=/).
+this about 5-minute [post-workshop survey](https://carpentries.typeform.com/to/cjJ9UP#slug=/).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
This PR is focused on improving the clarity and consistency of links across the instructor training, particularly when used in exercises that may be copied into etherpads (and thus not copy links without explicit text). Additional changes are listed below and generally connect to the legibility of links for both disabled and non-disabled users (including screen-reader software).

Changes:
1. Replace `[Linkname][url] [url][url]` in exercises by adding the word `at` between linkname and URL to sound more natural but still provide information in an etherpad-friendly way
2. Add periods where natural after sentence-ending links
3. Adjust some formatting and caption for images to improve display and accessibility
4. Adjust link text when large portions of a sentence are linked to reduce cognitive load from long link display
5. Consolidated 2 versions of bad teaching video to only use one with multilingual captions (probably should have been a separate PR but I got carried away)
6. Replace some quoted phrases with bolding for clarity
7. Adjust line breaks in some places (remove old style line breaks when editing section, ensure lists are spaced correctly for md, etc)