### PR TITLE
Glosario typo

### DIFF
--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -190,7 +190,7 @@ or processes may be submitted to satisfy this requirement! We have a few suggest
 
 - Serve as an Instructor or a Helper at a workshop
 - Attend a regional call, skill-up session, or other community programming
-- Submit a contribution to a Lesson, Glossario, or other Carpentries repository
+- Submit a contribution to a Lesson, Glosario, or other Carpentries repository
 
 ### Serve as an Instructor or Helper at a Carpentries Workshop
 If you attended Instructor Training because you want to get started participating in workshops as soon


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


Typo of Glosario (spelled with double "s") in the Carpentries Instructor Checkout Instructions page. I am making this change as part of my "Get Involved!" contribution for checkout.


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/policies/coc/).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
