### PR TITLE
update maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you want to preview this lesson locally, you will need the [{sandpaper} R pac
 - [Sarah Brown][brown_sarah]: @brownsarahm
 - [Nathaniel Porter][porter-nathaniel]: @ndporter
 - [Karen Cranston][cranston-karen]: @kcranston
-- [John Wheeler][wheeler_jon]: @jonathanwheeler01
+- [Jon Wheeler][wheeler_jon]: @jonathanwheeler01
 
 [swc-site]: https://software-carpentry.org
 [dc-site]: https://datacarpentry.org

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to preview this lesson locally, you will need the [{sandpaper} R pac
 [lesson-doc]: https://carpentries.github.io/sandpaper-docs
 [brown_sarah]: https://github.com/brownsarahm
 [porter-nathaniel]: https://github.com/ndporter
-[wheeler_jon]: https://github.com/konathanwheeler01
+[wheeler_jon]: https://github.com/jonathanwheeler01
 [cranston-karen]: https://github.com/kcranston
 
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ If you want to preview this lesson locally, you will need the [{sandpaper} R pac
 [dc-site]: https://datacarpentry.org
 [lc-site]: https://librarycarpentry.org
 [lesson-doc]: https://carpentries.github.io/sandpaper-docs
-[brown_sarah]: https://carpentries.org/instructors/#brownsarahm
-[perez-suarez_david]: https://carpentries.org/instructors/#dpshelio
-[porter-nathaniel]: https://carpentries.org/instructors/#ndporter
-[wheeler_jon]: https://carpentries.org/instructors/#jonathanwheeler01
-[word_karen]: https://carpentries.org/team/
-[cranston-karen]: https://carpentries.org/community/instructors/
+[brown_sarah]: https://github.com/brownsarahm
+[porter-nathaniel]: https://github.com/ndporter
+[wheeler_jon]: https://github.com/konathanwheeler01
+[cranston-karen]: https://github.com/kcranston
 
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ If you want to preview this lesson locally, you will need the [{sandpaper} R pac
 
 - [Sarah Brown][brown_sarah]: @brownsarahm
 - [Nathaniel Porter][porter-nathaniel]: @ndporter
-- [Jon Wheeler][wheeler_jon]: @jonathanwheeler01
-- [Karen Word][word_karen]: @karenword
+- [Karen Cranston][cranston-karen]: @kcranston
+- [John Wheeler][wheeler_jon]: @jonathanwheeler01
 
 [swc-site]: https://software-carpentry.org
 [dc-site]: https://datacarpentry.org
@@ -27,6 +27,6 @@ If you want to preview this lesson locally, you will need the [{sandpaper} R pac
 [porter-nathaniel]: https://carpentries.org/instructors/#ndporter
 [wheeler_jon]: https://carpentries.org/instructors/#jonathanwheeler01
 [word_karen]: https://carpentries.org/team/
-
+[cranston-karen]: https://carpentries.org/community/instructors/
 
 


### PR DESCRIPTION
Set list to people on the [team](https://github.com/orgs/carpentries/teams/instructor-training-maintainers) except core team members, unless any of them should be? 

In trying to do this, I realized the links for all of us are no longer actually specific... 

I see a few options:
- link to github profiles (my preference)
- link to pages we each provide (more work to maintain?)

Alternatively, we could also link to the team page and not maintain this text in the repo. 

Finally, not super consequential, but I am currently labeled as a maintainer of the team. Maybe that should be someone who is a member of the leadership committee + a maintainer or a core team member? 