### PR TITLE
Adjust whitespace within question, objective, keypoint fenced divs

### DIFF
--- a/episodes/02-practice-learning.md
+++ b/episodes/02-practice-learning.md
@@ -5,20 +5,24 @@ teaching: 30
 exercises: 30
 ---
 
-::: objectives
+::::::::::::::::::::::::::::::::::::::: objectives
+
 -   Compare and contrast the three stages of skill acquisition.
 -   Identify a mental model and an analogy that can help to explain it.
 -   Apply a concept map to explore a simple mental model.
 -   Understand the limitations of knowledge in the absence of a
     functional mental model.
 -   Create a formative assessment to diagnose a broken mental model.
-:::
 
-::: questions
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::: questions
+
 -   How do people learn?
 -   Who is a typical Carpentries learner?
 -   How can we help novices become competent practitioners?
-:::
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 We will now get started with a discussion of how learning works. We will
 begin with some key concepts from educational research and identify how
@@ -553,7 +557,8 @@ attention to!) feedback from learners. We will be talking in more depth
 about each of these strategies as we go forward in our workshop.
 :::
 
-::: keypoints
+:::::::::::::::::::::::::::::::::::::: keypoints
+
 -   Our goal when teaching novices is to help them construct useful
     mental models.
 -   Exploring our own mental models can help us prepare to convey them.
@@ -561,4 +566,5 @@ about each of these strategies as we go forward in our workshop.
     feedback.
 -   Formative assessments provide practice for learners and feedback to
     learners and instructors.
-:::
+
+::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
The row for _Building Skill with Practice_ in the schedule table includes some stray `:::`, which I think is a consequence of there being no empty lines between the fences and the content of the `questions` div. This PR adds empty lines to that div as well as the `objectives` and `keypoints`. I also adjusted the length of the fences, to make them more consistent with the style of the other episodes.

_[Edited to add screenshot.]_

<img width="906" height="430" alt="Screenshot 2025-07-10 at 13 17 09" src="https://github.com/user-attachments/assets/43f42ce2-7d10-4b27-905d-489ebe54e9f5" />

