### PR TITLE
Host and caption tip for trainers

### DIFF
--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -23,8 +23,8 @@ exercises: 15
 
 
 :::::::::::::::::::::::::::::::::::::::instructor
-In an online training, ensure that captions are turned on.
-
+In an online training, ensure that captions are turned on and that one trainer claims host. 
+The host key is in the email to trainers from the core team prior to the training. 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 

--- a/episodes/08-motivation.md
+++ b/episodes/08-motivation.md
@@ -20,6 +20,12 @@ exercises: 30
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+
+:::::::::::::::::::::::::::::::::::::::instructor
+In an online training, ensure that captions are turned on and that one trainer claims host. 
+The host key is in the email to trainers from the core team prior to the training. 
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
 ## Motivation Matters
 
 Teaching and learning are not the same process. As we have seen, an instructor can make choices that facilitate the cognitive processes

--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -5,6 +5,13 @@ teaching: 20
 exercises: 25
 ---
 
+
+:::::::::::::::::::::::::::::::::::::::instructor
+In an online training, ensure that captions are turned on and that one trainer claims host. 
+The host key is in the email to trainers from the core team prior to the training. 
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
 
 - CK: Not an "official" exercise, but after explaining the workshops and how to run them,

--- a/episodes/20-performance.md
+++ b/episodes/20-performance.md
@@ -17,7 +17,15 @@ exercises: 25
 - How did you change your teaching in response to feedback?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
-  
+
+
+
+:::::::::::::::::::::::::::::::::::::::instructor
+In an online training, ensure that captions are turned on and that one trainer claims host. 
+The host key is in the email to trainers from the core team prior to the training. 
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+
 Continuing our theme of developing practical Carpentries teaching skills,
 this section provides another chance to practice live coding, to go through the
 process of observing and giving feedback, and to make changes to how we teach based on the feedback of others.


### PR DESCRIPTION
- Adds to the intstructor note about captions to remind trainers to claim host and where to find the host key in 01-welcome
- Copies that same instructor note to the start of each part
