### PR TITLE
Standardize role capitalization

### DIFF
--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -166,7 +166,7 @@ organisation before starting the training.
 
 ## A Brief Overview of The Carpentries
 
-![](fig/Scene_1_blue_stickies_labeled.jpeg){alt='Image of action figures in a workshop with Instructor, Co-Instructor, Helper, and Sticky Notes labeled' width="900px" }
+![](fig/Scene_1_blue_stickies_labeled.jpeg){alt='Image of action figures in a workshop with Instructor, Co-Instructor, helper, and Sticky Notes labeled' width="900px" }
 
 Software Carpentry, Data Carpentry, and Library Carpentry
 are official Lesson Programs of The Carpentries.

--- a/episodes/02-practice-learning.md
+++ b/episodes/02-practice-learning.md
@@ -461,7 +461,7 @@ This discussion should take about 5 minutes.
     have a widespread misconception and can stop to examine and correct
     that misconception.
 2.  If most of the class votes for the right answer, it is ok to explain
-    the answer and move on. helpers can make themselves available to
+    the answer and move on. Helpers can make themselves available to
     assist anyone who still feels uncertain.
 3.  If answers are pretty evenly split between options, learners may be
     guessing randomly, reflecting an absent mental model rather than a

--- a/episodes/02-practice-learning.md
+++ b/episodes/02-practice-learning.md
@@ -461,7 +461,7 @@ This discussion should take about 5 minutes.
     have a widespread misconception and can stop to examine and correct
     that misconception.
 2.  If most of the class votes for the right answer, it is ok to explain
-    the answer and move on. Helpers can make themselves available to
+    the answer and move on. helpers can make themselves available to
     assist anyone who still feels uncertain.
 3.  If answers are pretty evenly split between options, learners may be
     guessing randomly, reflecting an absent mental model rather than a

--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -118,7 +118,7 @@ certified instructors.
 
 The handbook includes several helpful [Workshop Checklists and Suggestions][docs-workshop-checklists]: [https://docs.carpentries.org/resources/workshops/checklists.html](https://docs.carpentries.org/resources/workshops/checklists.html) 
 
-The Helper checklist recommends at least a 1:10
+The helper checklist recommends at least a 1:10
 helper-to-learner ratio for in-person workshops (not counting instructors) and more if teaching online.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -191,16 +191,16 @@ independently, or to host workshops beyond the areas of expertise you may have l
 
 If you have enough local Instructors available to organise your own workshop, you can run a self-organised workshop at any time at no cost. If you need support with AWS instances for a Genomics 
 workshop, there may be an associated fee. You can learn more about Genomic workshops in the [Genomics Workshops Terms of Agreement](https://docs.carpentries.org/resources/workshops/genomics_policy.html).
-If you would like to recruit additional Instructors or Helpers, [this blog post][SO-recruiting-blog] has guidelines for using Carpentries communications channels. Registering
+If you would like to recruit additional Instructors or helpers, [this blog post][SO-recruiting-blog] has guidelines for using Carpentries communications channels. Registering
 your workshop with us allows you to use The Carpentries branding, includes our pre- and post- workshop surveys and results for your workshop, and ensures
-that all Instructors and Helpers in our database have the experience recorded in their profile. Registering your workshop also helps us: reporting
+that all Instructors and helpers in our database have the experience recorded in their profile. Registering your workshop also helps us: reporting
 on our global impact is vital to our future funding opportunities, allowing us to continue to provide and develop materials and opportunities for you.
 
 Once you have selected your workshop type, consult [**The Carpentries Handbook**][docs] for more resources to support your organising effort.
 The Carpentries Handbook is the definitive source for policies and information, including tips, checklists, and points of contact for nearly all
 Carpentries-related activities. A few examples of useful content include:
 
-- [template emails and checklists][docs-teach-host] for Hosts, Instructors, and Helpers
+- [template emails and checklists][docs-teach-host] for hosts, Instructors, and helpers
 - the [instructor no-show policy][docs-noshow] which is important to read before signing up for your first workshop
 
 As The Carpentries grows and changes in response to a complex global legal landscape, our policies and procedures are likely to change. Be sure to check

--- a/episodes/18-preparation.md
+++ b/episodes/18-preparation.md
@@ -53,7 +53,7 @@ their Instructor Training event.
 
 ## Using this page as a resource
 
-Your trainers may not cover everything here during Instructor Training because the material is designed to be a valuable ongoing reference. We encourage you to keep this episode handy as a resource when preparing for a workshop.
+Your Trainers may not cover everything here during Instructor Training because the material is designed to be a valuable ongoing reference. We encourage you to keep this episode handy as a resource when preparing for a workshop.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -273,7 +273,7 @@ we will talk about how to prepare with your team to create a cohesive classroom 
 
 ## Minute Cards Revisited
 
-Use your sticky notes or the form provided by your trainers to write minute cards
+Use your sticky notes or the form provided by your Trainers to write minute cards
 as discussed [in part 1](06-feedback.md#minute-cards).
 
 

--- a/episodes/21-management.md
+++ b/episodes/21-management.md
@@ -27,7 +27,7 @@ exercises: 40
 
 One of the greatest strengths of Carpentries workshops compared with many other instructional settings is that workshops are prepared and executed
 by more than one person. We ask that at least two Instructors teach in every workshop, and some workshops may have many more! During the workshop,
-you should also have a crew of Helpers to answer questions individually, elevate common problems for general discussion, and make sure the pacing
+you should also have a crew of helpers to answer questions individually, elevate common problems for general discussion, and make sure the pacing
 works for everyone.
 
 The people who are planning and executing your workshop with you can really lighten the load! They are also there to
@@ -41,20 +41,20 @@ our instructions for setting up a workshop website.
 
 A typical Carpentries workshop includes 3 roles; sometimes individuals may choose to play more than one role. Each workshop should have:
 
-- A **Host** who organises the workshop logistics
+- A **host** who organises the workshop logistics
 - Two or more **Instructors** who plan and execute workshop instruction
-- **Helpers** who support learners during the workshop
+- **helpers** who support learners during the workshop
 
 ### Hosting
 
 We will not spend a lot of time talking about the host role, because most of what they do is not directly related to teaching. However, this is
 a significant role in any workshop. A suggested checklist for this role is in [The Carpentries Handbook][host-checklist].
 
-When Instructors self-organise a workshop, they sometimes find themselves playing the role of Host as well as Instructor.
+When Instructors self-organise a workshop, they sometimes find themselves playing the role of host as well as Instructor.
 We recommend avoiding this if possible, because hosting responsibilities will subtract from the time you have
 to prepare and teach.
 
-If you cannot find someone else to bear full responsibility for the Host role, consider recruiting help for specific tasks. This may include
+If you cannot find someone else to bear full responsibility for the host role, consider recruiting help for specific tasks. This may include
 involving helpers in advance of the workshop, or exploring institutional support for event logistics like registration, snack delivery,
 helper coordination, and emergency contact.
 
@@ -77,7 +77,7 @@ considering for self-organised workshops if a co-Instructor has not yet been cer
 
 ### Helpers
 
-[Helpers][helpers] are usually recruited from a local community by the Host of a workshop. Helpers may be
+[Helpers][helpers] are usually recruited from a local community by the host of a workshop. Helpers may be
 involved prior to the day of the workshop, but often they simply show up. In most cases, helpers are expected to
 attend for the full workshop, but in some communities they may come and go during different segments.
 
@@ -318,10 +318,10 @@ there is work to do when planning a workshop! But there is much to be gained in 
 ## Teaching Together - Nuts and Bolts
 
 With a partner, imagine that you are planning a workshop together. For this exercise, you may assume
-that your workshop has a separate, designated Host.
+that your workshop has a separate, designated host.
 
 - How would you prepare to teach a workshop together?
-- How would you coordinate with other members of your instructional team (e.g. Host, Helpers)?
+- How would you coordinate with other members of your instructional team (e.g. host, helpers)?
 - What kinds of things will you do to support each other during the workshop? What won't you do?
 
 Record some notes, and share your thoughts with the group. This exercise should take about 10 minutes.

--- a/episodes/23-introductions.md
+++ b/episodes/23-introductions.md
@@ -26,7 +26,7 @@ workshop experience: the introduction and the conclusion.
 Because these take time away from content instruction, it can be tempting to avoid investing precious
 preparation and class time to these sections. However, a strong introduction sets the tone for your workshop, teaches learners how to engage, and inspires
 confidence that learners will get what they need. A solid conclusion helps learners to solidify what they have learned and plan their next steps, and sends 
-everyone -- including Instructors and Helpers -- home with a sense of accomplishment. In this section, we will work together to identify ingredients that can
+everyone -- including Instructors and helpers -- home with a sense of accomplishment. In this section, we will work together to identify ingredients that can
 make these moments stand out and dedicate some practice time as well.
 
 ## Launching your Workshop: The Introduction

--- a/episodes/25-wrap-up.md
+++ b/episodes/25-wrap-up.md
@@ -53,7 +53,7 @@ This exercise should take 5 minutes.
 
 ::: instructor
 
-You will need to get the post-training survey link yourself and provide it in the activity below. It should follow the form `https://carpentries.typeform.com/to/cjJ9UP#slug=...../` and can be found in an email trainers receive from the Carpentries Core Team before the training.
+You will need to get the post-training survey link yourself and provide it in the activity below. It should follow the form `https://carpentries.typeform.com/to/cjJ9UP#slug=...../` and can be found in an email Trainers receive from the Carpentries Core Team before the training.
 
 :::
 
@@ -62,7 +62,7 @@ You will need to get the post-training survey link yourself and provide it in th
 ## Post Workshop Surveys
 
 Assessment is very important to us! Please take the remaining time to complete
-this about 5-minute post-training survey (your trainers will provide the link).
+this about 5-minute post-training survey (your Trainers will provide the link).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -100,7 +100,7 @@ what pads can be used for, and how long pads stick around. You may also want to 
 - Most people like or enjoy this training.
 - There is no such thing as "too much coffee" or "too many donuts"
 
-### Using Helpers/Co-Instructors
+### Using helpers/Co-Instructors
 
 If you have a helper for the training, or want to involve your co-instructor more,
 here are some ways where it is easy to do so without much prep:

--- a/learners/checkout.md
+++ b/learners/checkout.md
@@ -188,16 +188,16 @@ The purpose of this step is to encourage you to take a first step towards furthe
 The Carpentries, choosing a path that works well for you. Any participation in Carpentries activities
 or processes may be submitted to satisfy this requirement! We have a few suggestions to get you started:
 
-- Serve as an Instructor or a Helper at a workshop
+- Serve as an Instructor or a helper at a workshop
 - Attend a regional call, skill-up session, or other community programming
 - Submit a contribution to a Lesson, Glosario, or other Carpentries repository
 
-### Serve as an Instructor or Helper at a Carpentries Workshop
+### Serve as an Instructor or helper at a Carpentries Workshop
 If you attended Instructor Training because you want to get started participating in workshops as soon
 as possible, this step is for you! When you submit this step, you will be asked to share the date and
 workshop website link.
 
-Did you serve as a Helper or un-certified co-Instructor before you attended Instructor Training?
+Did you serve as a helper or un-certified co-Instructor before you attended Instructor Training?
 That counts!
 
 ### Attend a Regional Call, Skill-Up Session, or Other Community Programming


### PR DESCRIPTION
**Summary**
- Standardize capitalization of role terms across the curriculum to match the style guide.
- Capitalize: Instructor, Trainer/Trainers
- Lowercase: helper(s), host(s)
- Updated headings, body text, and one image alt text
- No content/meaning changes

**Issue**
Closes #1843.