### PR TITLE
Remove mention of MCQ in E1 key points

### DIFF
--- a/episodes/01-welcome.md
+++ b/episodes/01-welcome.md
@@ -260,7 +260,7 @@ workshops specifically.
 - The Carpentries is a community of practice. We strive to provide a welcoming environment for all learners and take our Code of Conduct seriously.
 - This episode sets the stage for the entire training. The introductions and exercises help everyone begin to develop a relationship and trust.
 - This training will cover evidence-based teaching practices and how they apply specifically to The Carpentries.
-- Learner motivation and prior knowledge vary widely, and can be quickly assessed with a multiple choice question.
+- Learner motivation and prior knowledge vary widely.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
Closes #1820. Removes reference to multiple choice questions as a formative assessment tool in keypoints box, as MCQs are not discussed until a later lesson (though they are used in E1).
