### PR TITLE
Fix grammar in licensing statement for Carpentries lessons

### DIFF
--- a/episodes/15-carpentries.md
+++ b/episodes/15-carpentries.md
@@ -249,7 +249,7 @@ Library Carpentry lesson format, you can find two Workbench lesson templates ava
 - [RMarkdown][template-rmd]: this template is suitable for lessons that include executable R code
 
 Any lesson that uses The Carpentries lesson templates follows our [Code of Conduct][coc], 
-and is licensed either [CC-BY][cc-by] or [CC-0][cc-0] can be hosted in [The Carpentries Incubator][carpentries-incubator].
+and is licensed either [CC-BY][cc-by] or [CC-0][cc-0] so it can be hosted in [The Carpentries Incubator][carpentries-incubator].
 
 The [Collaborative Lesson Development Training][cld] curriculum provides a guide to
 the backward design approach we recommend for lesson development. This curriculum is part of our official


### PR DESCRIPTION
Add missing works to the licensing statement to correct grammar